### PR TITLE
Fix React 16 compatibility issues; various other patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-/lib
 
 # vim .sw files
 *.sw*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 /lib
+
+# vim .sw files
+*.sw*

--- a/lib/Div100vh.test.js
+++ b/lib/Div100vh.test.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var _react = _interopRequireDefault(require("react"));
+
+var _reactDom = _interopRequireDefault(require("react-dom"));
+
+var _index = _interopRequireDefault(require("./index.jsx"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+describe('Div100vh', function () {
+  it('renders without crashing', function () {
+    var div = document.createElement('div');
+
+    _reactDom.default.render(_react.default.createElement(_index.default, null), div);
+
+    _reactDom.default.unmountComponentAtNode(div);
+  });
+  it('renders without crashing when createRef is not supported', function () {
+    _react.default.createRef = null;
+    var div = document.createElement('div');
+
+    _reactDom.default.render(_react.default.createElement(_index.default, null), div);
+
+    _reactDom.default.unmountComponentAtNode(div);
+  });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,12 +99,12 @@ function (_React$Component) {
     key: "componentDidMount",
     value: function componentDidMount() {
       this.computeRvhStyles();
-      window.addEventListener('resize', this.computeRvhStyles);
+      window.addEventListener('resize', this.computeRvhStyles, false);
     }
   }, {
     key: "componentWillUnmount",
     value: function componentWillUnmount() {
-      window.removeEventListener('resize', this.computeRvhStyles);
+      window.removeEventListener('resize', this.computeRvhStyles, false);
     }
   }, {
     key: "render",

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,24 +44,38 @@ var Div100vh =
 function (_React$Component) {
   _inherits(Div100vh, _React$Component);
 
-  function Div100vh() {
+  function Div100vh(props) {
     var _this;
 
     _classCallCheck(this, Div100vh);
 
-    _this = _possibleConstructorReturn(this, _getPrototypeOf(Div100vh).call(this));
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(Div100vh).call(this, props));
     _this.myRef = _react.default.createRef ? _react.default.createRef() : null;
     _this.computeRvhStyles = _this.computeRvhStyles.bind(_assertThisInitialized(_assertThisInitialized(_this)));
     return _this;
-  } // On window resize, recalculate any rvh unit style properties
-
+  }
 
   _createClass(Div100vh, [{
+    key: "getRef",
+    value: function getRef() {
+      return this.myRef ? this.myRef.current || this.myRef : null;
+    }
+  }, {
+    key: "setNodeHeightToWindowInnerHeight",
+    value: function setNodeHeightToWindowInnerHeight() {
+      var node = this.getRef();
+      return node ? node.style.height = window.innerHeight + 'px' : null;
+    } // On window resize, recalculate any rvh unit style properties
+
+  }, {
     key: "computeRvhStyles",
     value: function computeRvhStyles() {
-      if (!this.props.style) return;
-      var node = this.myRef.current;
+      if (!this.props.style) {
+        return this.setNodeHeightToWindowInnerHeight();
+      }
+
       var rvhPropertyFound = false;
+      var node = this.getRef();
       Object.entries(this.props.style).forEach(function (_ref) {
         var _ref2 = _slicedToArray(_ref, 2),
             property = _ref2[0],
@@ -69,7 +83,7 @@ function (_React$Component) {
 
         var match = rvhRegex.exec(rawValue);
 
-        if (match != null) {
+        if (node && match != null) {
           rvhPropertyFound = true; // Guarantee that this only runs for numbers
 
           var extractedValue = parseFloat(match[0]);
@@ -78,7 +92,7 @@ function (_React$Component) {
       }); // Default to height 100vh if no rvh found in style
 
       if (!rvhPropertyFound) {
-        node.style.height = window.innerHeight + 'px';
+        this.setNodeHeightToWindowInnerHeight();
       }
     }
   }, {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,112 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }
+
+function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+var rvhRegex = /(\d+(\.\d*)?)rvh\s*$/;
+
+var Div100vh =
+/*#__PURE__*/
+function (_React$Component) {
+  _inherits(Div100vh, _React$Component);
+
+  function Div100vh() {
+    var _this;
+
+    _classCallCheck(this, Div100vh);
+
+    _this = _possibleConstructorReturn(this, _getPrototypeOf(Div100vh).call(this));
+    _this.myRef = _react.default.createRef ? _react.default.createRef() : null;
+    _this.computeRvhStyles = _this.computeRvhStyles.bind(_assertThisInitialized(_assertThisInitialized(_this)));
+    return _this;
+  } // On window resize, recalculate any rvh unit style properties
+
+
+  _createClass(Div100vh, [{
+    key: "computeRvhStyles",
+    value: function computeRvhStyles() {
+      if (!this.props.style) return;
+      var node = this.myRef.current;
+      var rvhPropertyFound = false;
+      Object.entries(this.props.style).forEach(function (_ref) {
+        var _ref2 = _slicedToArray(_ref, 2),
+            property = _ref2[0],
+            rawValue = _ref2[1];
+
+        var match = rvhRegex.exec(rawValue);
+
+        if (match != null) {
+          rvhPropertyFound = true; // Guarantee that this only runs for numbers
+
+          var extractedValue = parseFloat(match[0]);
+          node.style[property] = extractedValue / 100 * window.innerHeight + 'px';
+        }
+      }); // Default to height 100vh if no rvh found in style
+
+      if (!rvhPropertyFound) {
+        node.style.height = window.innerHeight + 'px';
+      }
+    }
+  }, {
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      this.computeRvhStyles();
+      window.addEventListener('resize', this.computeRvhStyles);
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      window.removeEventListener('resize', this.computeRvhStyles);
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _this2 = this;
+
+      return _react.default.createElement("div", _extends({
+        ref: this.myRef || function (el) {
+          return _this2.myRef = el;
+        }
+      }, this.props));
+    }
+  }]);
+
+  return Div100vh;
+}(_react.default.Component);
+
+var _default = Div100vh;
+exports.default = _default;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-div-100vh",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-div-100vh",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-div-100vh",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A React component that aims to solve '100vh' issue in mobile browsers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/lib/Div100vh.test.js
+++ b/src/lib/Div100vh.test.js
@@ -2,8 +2,17 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Div100vh from './index.jsx'
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<Div100vh />, div);
-  ReactDOM.unmountComponentAtNode(div);
+describe('Div100vh', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<Div100vh />, div);
+    ReactDOM.unmountComponentAtNode(div);
+  });
+
+  it('renders without crashing when createRef is not supported', () => {
+    React.createRef = null;
+    const div = document.createElement('div');
+    ReactDOM.render(<Div100vh />, div);
+    ReactDOM.unmountComponentAtNode(div);
+  });
 });

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -51,11 +51,11 @@ class Div100vh extends React.Component {
 
   componentDidMount() {
     this.computeRvhStyles();
-    window.addEventListener('resize', this.computeRvhStyles);
+    window.addEventListener('resize', this.computeRvhStyles, false);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.computeRvhStyles);
+    window.removeEventListener('resize', this.computeRvhStyles, false);
   }
 
   render() {

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -5,7 +5,9 @@ const rvhRegex = /(\d+(\.\d*)?)rvh\s*$/;
 class Div100vh extends React.Component {
   constructor() {
     super();
-    this.myRef = React.createRef();
+    this.myRef = React.createRef ?
+      React.createRef() :
+      null;
     this.computeRvhStyles = this.computeRvhStyles.bind(this);
   }
 
@@ -40,7 +42,15 @@ class Div100vh extends React.Component {
   }
 
   render() {
-    return <div ref={this.myRef} {...this.props} />;
+    return (
+      <div
+        ref={
+          this.myRef ||
+            (el => this.myRef = el)
+        }
+        {...this.props}
+      />
+    );
   }
 }
 

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -3,32 +3,49 @@ import React from 'react';
 const rvhRegex = /(\d+(\.\d*)?)rvh\s*$/;
 
 class Div100vh extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.myRef = React.createRef ?
       React.createRef() :
       null;
     this.computeRvhStyles = this.computeRvhStyles.bind(this);
   }
 
+  getRef() {
+    return this.myRef ?
+      (this.myRef.current || this.myRef) :
+      null;
+  }
+
+  setNodeHeightToWindowInnerHeight() {
+    const node = this.getRef();
+    return node ?
+      node.style.height = window.innerHeight + 'px' :
+      null;
+  }
+
   // On window resize, recalculate any rvh unit style properties
   computeRvhStyles() {
-    if (!this.props.style) return;
+    if (!this.props.style) {
+      return this.setNodeHeightToWindowInnerHeight();
+    }
 
-    const node = this.myRef.current;
     let rvhPropertyFound = false;
+    const node = this.getRef();
+
     Object.entries(this.props.style).forEach(([property, rawValue]) => {
       const match = rvhRegex.exec(rawValue);
-      if (match != null) {
+      if (node && match != null) {
         rvhPropertyFound = true;
         // Guarantee that this only runs for numbers
         const extractedValue = parseFloat(match[0]);
         node.style[property] = extractedValue / 100 * window.innerHeight + 'px';
       }
     });
+
     // Default to height 100vh if no rvh found in style
     if (!rvhPropertyFound) {
-      node.style.height = window.innerHeight + 'px';
+      this.setNodeHeightToWindowInnerHeight();
     }
   }
 


### PR DESCRIPTION
Solves https://github.com/mvasin/react-div-100vh/issues/3 as well as a few other issues.

1. The npm package did not include the `lib` directory (it was in `.gitignore`), which rendered the library unusable as a package.  This branch includes the `lib` directory in source control
2. Iterates the version number in `package` and `package-lock`
3. Falls back to the legacy React ref callback syntax to ensure compatibility with React versions > 15 and < 16.3