### PR TITLE
Avoid to use jest-get-type in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "integrity": "sha512-SH/x7W1dz4FSSBeJZXIiYSbHIOU3ZxNgwQPLTG+I8KXyTS81pzmLouPa2st6hji7VbVrEF/D8EQzQbXAYj1TsA==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.3",
-        "commander": "^2.8.1",
-        "convert-source-map": "^1.1.0",
-        "fs-readdir-recursive": "^1.1.0",
-        "glob": "^7.0.0",
-        "lodash": "^4.17.10",
-        "mkdirp": "^0.5.1",
-        "output-file-sync": "^2.0.0",
-        "slash": "^2.0.0",
-        "source-map": "^0.5.0"
+        "chokidar": "2.0.4",
+        "commander": "2.15.1",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
+        "glob": "7.1.3",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "output-file-sync": "2.0.1",
+        "slash": "2.0.0",
+        "source-map": "0.5.7"
       }
     },
     "@babel/code-frame": {
@@ -28,7 +28,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/core": {
@@ -37,20 +37,20 @@
       "integrity": "sha512-nrvxS5u6QUN5gLl1GEakIcmOeoUHT1/gQtdMRq18WFURJ5osn4ppJLVSseMQo4zVWKJfBTF4muIYijXUnKlRLQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.0.0",
-        "@babel/helpers": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "convert-source-map": "^1.1.0",
-        "debug": "^3.1.0",
-        "json5": "^0.5.0",
-        "lodash": "^4.17.10",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.0.0",
+        "@babel/helpers": "7.0.0",
+        "@babel/parser": "7.0.0",
+        "@babel/template": "7.0.0",
+        "@babel/traverse": "7.0.0",
+        "@babel/types": "7.0.0",
+        "convert-source-map": "1.5.1",
+        "debug": "3.1.0",
+        "json5": "0.5.1",
+        "lodash": "4.17.10",
+        "resolve": "1.8.1",
+        "semver": "5.5.1",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -70,11 +70,11 @@
       "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.0.0",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -83,7 +83,7 @@
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -92,8 +92,8 @@
       "integrity": "sha512-9HdU8lrAc4FUZOy+y2w//kUhynSpkGIRYDzJW1oKJx7+v8m6UEAbAd2tSvxirsq2kJTXJZZS6Eo8FnUDUH0ZWw==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-explode-assignable-expression": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-builder-react-jsx": {
@@ -102,8 +102,8 @@
       "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0",
-        "esutils": "^2.0.0"
+        "@babel/types": "7.0.0",
+        "esutils": "2.0.2"
       }
     },
     "@babel/helper-call-delegate": {
@@ -112,9 +112,9 @@
       "integrity": "sha512-HdYG6vr4KgXHK0q1QRZ8guoYCF5rZjIdPlhcVY+j4EBK/FDR+cXRM5/6lQr3NIWDc7dO1KfgjG5rfH6lM89VBw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/traverse": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-define-map": {
@@ -123,9 +123,9 @@
       "integrity": "sha512-acbCxYS9XufWxsBiclmXMK1CFz7en/XSYvHFcbb3Jb8BqjFEBrA46WlIsoSQTRG/eYN60HciUnzdyQxOZhrHfw==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-function-name": "7.0.0",
+        "@babel/types": "7.0.0",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -134,8 +134,8 @@
       "integrity": "sha512-5gLPwdDnYf8GfPsjS+UmZUtYE1jaXTFm1P+ymGobqvXbA0q3ANgpH60+C6zDrRAWXYbQXYvzzQC/r0gJVNNltQ==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/traverse": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-function-name": {
@@ -144,9 +144,9 @@
       "integrity": "sha512-Zo+LGvfYp4rMtz84BLF3bavFTdf8y4rJtMPTe2J+rxYmnDOIeH8le++VFI/pRJU+rQhjqiXxE4LMaIau28Tv1Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -155,7 +155,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -164,7 +164,7 @@
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -173,7 +173,7 @@
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-module-imports": {
@@ -182,7 +182,7 @@
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-module-transforms": {
@@ -191,12 +191,12 @@
       "integrity": "sha512-QdwmTTlPmT7TZcf30dnqm8pem+o48tVt991xXogE5CQCwqSpWKuzH2E9v8VWeccQ66a6/CmrLZ+bwp66JYeM5A==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-simple-access": "^7.0.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-simple-access": "7.0.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/template": "7.0.0",
+        "@babel/types": "7.0.0",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -205,7 +205,7 @@
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -220,7 +220,7 @@
       "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -229,11 +229,11 @@
       "integrity": "sha512-3o4sYLOsK6m0A7t1P0saTanBPmk5MAlxVnp9773Of4L8PMVLukU7loZix5KoJgflxSo2c2ETTzseptc0rQEp7A==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-wrap-function": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-wrap-function": "7.0.0",
+        "@babel/template": "7.0.0",
+        "@babel/traverse": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-replace-supers": {
@@ -242,10 +242,10 @@
       "integrity": "sha512-fsSv7VogxzMSmGch6DwhKHGsciVXo7hbfhBgH9ZrgJMXKMjO7ASQTUfbVL7MU1uCfviyqjucazGK7TWPT9weuQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/traverse": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-simple-access": {
@@ -254,8 +254,8 @@
       "integrity": "sha512-CNeuX52jbQSq4j1n+R+21xrjbTjsnXa9n1aERbgHRD/p9h4Udkxr1n24yPMQmnTETHdnQDvkVSYWFw/ETAymYg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/template": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -264,7 +264,7 @@
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helper-wrap-function": {
@@ -273,10 +273,10 @@
       "integrity": "sha512-kjprWPDNVPZ/9pyLRXcZBvfjnFwqokmXTPTaC4AV8Ns7WRl7ewSxrB19AWZzQsC/WSPQLOw1ciR8uPYkAM1znA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-function-name": "7.0.0",
+        "@babel/template": "7.0.0",
+        "@babel/traverse": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/helpers": {
@@ -285,9 +285,9 @@
       "integrity": "sha512-jbvgR8iLZPnyk6m/UqdXYsSxbVtRi7Pd3CzB4OPwPBnmhNG1DWjiiy777NTuoyIcniszK51R40L5pgfXAfHDtw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/template": "7.0.0",
+        "@babel/traverse": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/highlight": {
@@ -296,9 +296,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       },
       "dependencies": {
         "js-tokens": {
@@ -321,9 +321,9 @@
       "integrity": "sha512-QsXmmjLrFADCcDQAfdQn7tfBRLjpTzRWaDpKpW4ZXW1fahPG4SvjcF1xfvVnXGC662RSExYXL+6DAqbtgqMXeA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.0.0",
-        "@babel/plugin-syntax-async-generators": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.0.0",
+        "@babel/plugin-syntax-async-generators": "7.0.0"
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -332,12 +332,12 @@
       "integrity": "sha512-mVgsbdySh6kuzv4omXvw0Kuh+3hrUrQ883qTCf75MqfC6zctx2LXrP3Wt+bbJmB5fE5nfhf/Et2pQyrRy4j0Pg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.0.0",
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.0.0",
-        "@babel/plugin-syntax-class-properties": "^7.0.0"
+        "@babel/helper-function-name": "7.0.0",
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.0.0",
+        "@babel/plugin-syntax-class-properties": "7.0.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -346,8 +346,8 @@
       "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-json-strings": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-json-strings": "7.0.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -356,8 +356,8 @@
       "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -366,8 +366,8 @@
       "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -376,9 +376,9 @@
       "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -387,7 +387,7 @@
       "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-class-properties": {
@@ -396,7 +396,7 @@
       "integrity": "sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -405,7 +405,7 @@
       "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-jsx": {
@@ -414,7 +414,7 @@
       "integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -423,7 +423,7 @@
       "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -432,7 +432,7 @@
       "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -441,7 +441,7 @@
       "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -450,9 +450,9 @@
       "integrity": "sha512-CiWNhSMZzj1n3uEKUUS/oL+a7Xi8hnPQB6GpC1WfL/ZYvxBLDBn14sHMo5EyOaeArccSonyk5jFIKMRRbrHOnQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.0.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -461,7 +461,7 @@
       "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -470,8 +470,8 @@
       "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "lodash": "4.17.10"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -480,14 +480,14 @@
       "integrity": "sha512-8LBm7XsHQiNISEmb+ejBiHi1pUihwUf+lrIwyVsXVbQ1vLqgkvhgayK5JnW3WXvQD2rmM0qxFAIyDE5vtMem2A==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.0.0",
-        "@babel/helper-function-name": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.0.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "globals": "^11.1.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-define-map": "7.0.0",
+        "@babel/helper-function-name": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.0.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "globals": "11.7.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
@@ -496,7 +496,7 @@
       "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -505,7 +505,7 @@
       "integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -514,9 +514,9 @@
       "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
@@ -525,7 +525,7 @@
       "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -534,8 +534,8 @@
       "integrity": "sha512-Ig74elCuFQ0mvHkWUq5qDCNI3qHWlop5w4TcDxdtJiOk8Egqe2uxDRY9XnXGSlmWClClmnixcoYumyvbAuj4dA==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -544,7 +544,7 @@
       "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -553,8 +553,8 @@
       "integrity": "sha512-mR7JN9vkwsAIot74pSwzn/2Gq4nn2wN0HKtQyJLc1ghAarsymdBMTfh+Q/aeR2N3heXs3URQscTLrKe3yUU7Yw==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-function-name": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -563,7 +563,7 @@
       "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -572,8 +572,8 @@
       "integrity": "sha512-CtSVpT/0tty/4405qczoIHm41YfFbPChplsmfBwsi3RTq/M9cHgVb3ixI5bqqgdKkqWwSX2sXqejvMKLuTVU+Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -582,9 +582,9 @@
       "integrity": "sha512-BIcQLgPFCxi7YygtNpz5xj+7HxhOprbCGZKeLW6Kxsn1eHS6sJZMw4MfmqFZagl/v6IVa0AJoMHdDXLVrpd3Aw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.0.0"
+        "@babel/helper-module-transforms": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-simple-access": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -593,8 +593,8 @@
       "integrity": "sha512-8EDKMAsitLkiF/D4Zhe9CHEE2XLh4bfLbb9/Zf3FgXYQOZyZYyg7EAel/aT2A7bHv62jwHf09q2KU/oEexr83g==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -603,8 +603,8 @@
       "integrity": "sha512-EMyKpzgugxef+R1diXDwqw/Hmt5ls8VxfI8Gq5Lo8Qp3oKIepkYG4L/mvE2dmZSRalgL9sguoPKbnQ1m96hVFw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -613,7 +613,7 @@
       "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -622,8 +622,8 @@
       "integrity": "sha512-BfAiF1l18Xr1shy1NyyQgLiHDvh/S7APiEM5+0wxTsQ+e3fgXO+NA47u4PvppzH0meJS21y0gZHcjnvUAJj8tQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.0.0"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -632,9 +632,9 @@
       "integrity": "sha512-eWngvRBWx0gScot0xa340JzrkA+8HGAk1OaCHDfXAjkrTFkp73Lcf+78s7AStSdRML5nzx5aXpnjN1MfrjkBoA==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.0.0",
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-call-delegate": "7.0.0",
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-react-display-name": {
@@ -643,7 +643,7 @@
       "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-react-jsx": {
@@ -652,9 +652,9 @@
       "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-react-jsx": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.0.0"
+        "@babel/helper-builder-react-jsx": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.0.0"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
@@ -663,8 +663,8 @@
       "integrity": "sha512-pymy+AK12WO4safW1HmBpwagUQRl9cevNX+82AIAtU1pIdugqcH+nuYP03Ja6B+N4gliAaKWAegIBL/ymALPHA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.0.0"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
@@ -673,8 +673,8 @@
       "integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-jsx": "7.0.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -683,7 +683,7 @@
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.13.3"
+        "regenerator-transform": "0.13.3"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -692,7 +692,7 @@
       "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -701,7 +701,7 @@
       "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -710,8 +710,8 @@
       "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0"
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -720,8 +720,8 @@
       "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -730,7 +730,7 @@
       "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -739,9 +739,9 @@
       "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.2.0"
       }
     },
     "@babel/preset-env": {
@@ -750,47 +750,47 @@
       "integrity": "sha512-Fnx1wWaWv2w2rl+VHxA9si//Da40941IQ29fKiRejVR7oN1FxSEL8+SyAX/2oKIye2gPvY/GBbJVEKQ/oi43zQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-        "@babel/plugin-proposal-json-strings": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
-        "@babel/plugin-syntax-async-generators": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.0.0",
-        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.0.0",
-        "@babel/plugin-transform-dotall-regex": "^7.0.0",
-        "@babel/plugin-transform-duplicate-keys": "^7.0.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
-        "@babel/plugin-transform-for-of": "^7.0.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-amd": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.0.0",
-        "@babel/plugin-transform-modules-umd": "^7.0.0",
-        "@babel/plugin-transform-new-target": "^7.0.0",
-        "@babel/plugin-transform-object-super": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-template-literals": "^7.0.0",
-        "@babel/plugin-transform-typeof-symbol": "^7.0.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "browserslist": "^4.1.0",
-        "invariant": "^2.2.2",
-        "js-levenshtein": "^1.1.3",
-        "semver": "^5.3.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "7.0.0",
+        "@babel/plugin-proposal-json-strings": "7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "7.0.0",
+        "@babel/plugin-syntax-async-generators": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.0.0",
+        "@babel/plugin-transform-arrow-functions": "7.0.0",
+        "@babel/plugin-transform-async-to-generator": "7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "7.0.0",
+        "@babel/plugin-transform-block-scoping": "7.0.0",
+        "@babel/plugin-transform-classes": "7.0.0",
+        "@babel/plugin-transform-computed-properties": "7.0.0",
+        "@babel/plugin-transform-destructuring": "7.0.0",
+        "@babel/plugin-transform-dotall-regex": "7.0.0",
+        "@babel/plugin-transform-duplicate-keys": "7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "7.0.0",
+        "@babel/plugin-transform-for-of": "7.0.0",
+        "@babel/plugin-transform-function-name": "7.0.0",
+        "@babel/plugin-transform-literals": "7.0.0",
+        "@babel/plugin-transform-modules-amd": "7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "7.0.0",
+        "@babel/plugin-transform-modules-systemjs": "7.0.0",
+        "@babel/plugin-transform-modules-umd": "7.0.0",
+        "@babel/plugin-transform-new-target": "7.0.0",
+        "@babel/plugin-transform-object-super": "7.0.0",
+        "@babel/plugin-transform-parameters": "7.0.0",
+        "@babel/plugin-transform-regenerator": "7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "7.0.0",
+        "@babel/plugin-transform-spread": "7.0.0",
+        "@babel/plugin-transform-sticky-regex": "7.0.0",
+        "@babel/plugin-transform-template-literals": "7.0.0",
+        "@babel/plugin-transform-typeof-symbol": "7.0.0",
+        "@babel/plugin-transform-unicode-regex": "7.0.0",
+        "browserslist": "4.1.0",
+        "invariant": "2.2.4",
+        "js-levenshtein": "1.1.3",
+        "semver": "5.5.1"
       }
     },
     "@babel/preset-react": {
@@ -799,11 +799,11 @@
       "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-transform-react-display-name": "7.0.0",
+        "@babel/plugin-transform-react-jsx": "7.0.0",
+        "@babel/plugin-transform-react-jsx-self": "7.0.0",
+        "@babel/plugin-transform-react-jsx-source": "7.0.0"
       }
     },
     "@babel/template": {
@@ -812,9 +812,9 @@
       "integrity": "sha512-VLQZik/G5mjYJ6u19U3W2u7eM+rA/NGzH+GtHDFFkLTKLW66OasFrxZ/yK7hkyQcswrmvugFyZpDFRW0DjcjCw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/types": "^7.0.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.0.0",
+        "@babel/types": "7.0.0"
       }
     },
     "@babel/traverse": {
@@ -823,15 +823,15 @@
       "integrity": "sha512-ka/lwaonJZTlJyn97C4g5FYjPOx+Oxd3ab05hbDr1Mx9aP1FclJ+SUHyLx3Tx40sGmOVJApDxE6puJhd3ld2kw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.0.0",
-        "@babel/helper-function-name": "^7.0.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "debug": "^3.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.0.0",
+        "@babel/helper-function-name": "7.0.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/parser": "7.0.0",
+        "@babel/types": "7.0.0",
+        "debug": "3.1.0",
+        "globals": "11.7.0",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "debug": {
@@ -851,9 +851,9 @@
       "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -862,8 +862,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -878,7 +878,7 @@
       "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
       "dev": true,
       "requires": {
-        "any-observable": "^0.3.0"
+        "any-observable": "0.3.0"
       }
     },
     "@sindresorhus/is": {
@@ -896,8 +896,8 @@
         "@webassemblyjs/helper-module-context": "1.5.13",
         "@webassemblyjs/helper-wasm-bytecode": "1.5.13",
         "@webassemblyjs/wast-parser": "1.5.13",
-        "debug": "^3.1.0",
-        "mamacro": "^0.0.3"
+        "debug": "3.1.0",
+        "mamacro": "0.0.3"
       },
       "dependencies": {
         "debug": {
@@ -929,7 +929,7 @@
       "integrity": "sha512-v7igWf1mHcpJNbn4m7e77XOAWXCDT76Xe7Is1VQFXc4K5jRcFrl9D0NrqM4XifQ0bXiuTSkTKMYqDxu5MhNljA==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -964,8 +964,8 @@
       "integrity": "sha512-zxJXULGPLB7r+k+wIlvGlXpT4CYppRz8fLUM/xobGHc9Z3T6qlmJD9ySJ2jknuktuuiR9AjnNpKYDECyaiX+QQ==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "mamacro": "^0.0.3"
+        "debug": "3.1.0",
+        "mamacro": "0.0.3"
       },
       "dependencies": {
         "debug": {
@@ -995,7 +995,7 @@
         "@webassemblyjs/helper-buffer": "1.5.13",
         "@webassemblyjs/helper-wasm-bytecode": "1.5.13",
         "@webassemblyjs/wasm-gen": "1.5.13",
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1015,7 +1015,7 @@
       "integrity": "sha512-TseswvXEPpG5TCBKoLx9tT7+/GMACjC1ruo09j46ULRZWYm8XHpDWaosOjTnI7kr4SRJFzA6MWoUkAB+YCGKKg==",
       "dev": true,
       "requires": {
-        "ieee754": "^1.1.11"
+        "ieee754": "1.1.12"
       }
     },
     "@webassemblyjs/leb128": {
@@ -1055,7 +1055,7 @@
         "@webassemblyjs/wasm-opt": "1.5.13",
         "@webassemblyjs/wasm-parser": "1.5.13",
         "@webassemblyjs/wast-printer": "1.5.13",
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1092,7 +1092,7 @@
         "@webassemblyjs/helper-buffer": "1.5.13",
         "@webassemblyjs/wasm-gen": "1.5.13",
         "@webassemblyjs/wasm-parser": "1.5.13",
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1131,8 +1131,8 @@
         "@webassemblyjs/helper-api-error": "1.5.13",
         "@webassemblyjs/helper-code-frame": "1.5.13",
         "@webassemblyjs/helper-fsm": "1.5.13",
-        "long": "^3.2.0",
-        "mamacro": "^0.0.3"
+        "long": "3.2.0",
+        "mamacro": "0.0.3"
       }
     },
     "@webassemblyjs/wast-printer": {
@@ -1143,7 +1143,7 @@
       "requires": {
         "@webassemblyjs/ast": "1.5.13",
         "@webassemblyjs/wast-parser": "1.5.13",
-        "long": "^3.2.0"
+        "long": "3.2.0"
       }
     },
     "abab": {
@@ -1158,7 +1158,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.20",
         "negotiator": "0.6.1"
       }
     },
@@ -1174,7 +1174,7 @@
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.0"
+        "acorn": "5.7.2"
       }
     },
     "acorn-globals": {
@@ -1183,7 +1183,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.0"
+        "acorn": "5.7.2"
       }
     },
     "ajv": {
@@ -1192,10 +1192,10 @@
       "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0",
-        "uri-js": "^4.2.1"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-keywords": {
@@ -1210,9 +1210,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "kind-of": {
@@ -1221,7 +1221,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -1268,7 +1268,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.1"
       }
     },
     "any-observable": {
@@ -1283,8 +1283,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       }
     },
     "append-transform": {
@@ -1293,7 +1293,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^2.0.0"
+        "default-require-extensions": "2.0.0"
       }
     },
     "aproba": {
@@ -1308,7 +1308,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -1359,7 +1359,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -1392,7 +1392,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "asn1.js": {
@@ -1401,9 +1401,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
@@ -1492,12 +1492,12 @@
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.7.6",
-        "caniuse-db": "^1.0.30000634",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^5.2.16",
-        "postcss-value-parser": "^3.2.3"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000846",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -1506,8 +1506,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000846",
+            "electron-to-chromium": "1.3.48"
           }
         }
       }
@@ -1530,9 +1530,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1553,11 +1553,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "has-ansi": {
@@ -1566,7 +1566,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-ansi": {
@@ -1575,7 +1575,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -1598,14 +1598,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -1622,9 +1622,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1633,9 +1633,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -1644,10 +1644,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -1656,10 +1656,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -1668,9 +1668,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-explode-class": {
@@ -1679,10 +1679,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-        "babel-helper-bindify-decorators": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-bindify-decorators": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -1691,11 +1691,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1704,8 +1704,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1714,8 +1714,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -1724,8 +1724,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -1734,9 +1734,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1745,11 +1745,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -1758,12 +1758,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -1772,8 +1772,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-jest": {
@@ -1782,8 +1782,8 @@
       "integrity": "sha512-wg1LJ2tzsafXqPFVgAsYsMCVD5U7kwJZAvbZIxVm27iOewsQw1BR7VZifDlMTEWVo3wasoPPyMdKXWCsfFPr3Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "^4.1.6",
-        "babel-preset-jest": "^23.2.0"
+        "babel-plugin-istanbul": "4.1.6",
+        "babel-preset-jest": "23.2.0"
       }
     },
     "babel-loader": {
@@ -1792,10 +1792,10 @@
       "integrity": "sha512-lBUGBz411lSfT+8MHPEaqIVQ44odS1D/wxuTMhijqHc9arZR6jhJEaJa0RpZlCSITZoeK6xoDXTaVTrSoFD7IQ==",
       "dev": true,
       "requires": {
-        "find-cache-dir": "^1.0.0",
-        "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "util.promisify": "^1.0.0"
+        "find-cache-dir": "1.0.0",
+        "loader-utils": "1.1.0",
+        "mkdirp": "0.5.1",
+        "util.promisify": "1.0.0"
       }
     },
     "babel-messages": {
@@ -1804,7 +1804,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1813,7 +1813,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -1822,10 +1822,10 @@
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-        "find-up": "^2.1.0",
-        "istanbul-lib-instrument": "^1.10.1",
-        "test-exclude": "^4.2.1"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "test-exclude": "4.2.2"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -1906,9 +1906,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-generators": "^6.5.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-generators": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -1917,9 +1917,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -1928,9 +1928,9 @@
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-syntax-class-constructor-call": "6.18.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -1939,10 +1939,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-plugin-syntax-class-properties": "^6.8.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -1951,11 +1951,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-class": "^6.24.1",
-        "babel-plugin-syntax-decorators": "^6.13.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-class": "6.24.1",
+        "babel-plugin-syntax-decorators": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1964,7 +1964,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1973,7 +1973,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1982,11 +1982,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.10"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1995,15 +1995,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -2012,8 +2012,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -2022,7 +2022,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -2031,8 +2031,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -2041,7 +2041,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -2050,9 +2050,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -2061,7 +2061,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -2070,9 +2070,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -2081,10 +2081,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -2093,9 +2093,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -2104,9 +2104,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -2115,8 +2115,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -2125,12 +2125,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -2139,8 +2139,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -2149,7 +2149,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -2158,9 +2158,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -2169,7 +2169,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -2178,7 +2178,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -2187,9 +2187,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       },
       "dependencies": {
         "jsesc": {
@@ -2204,9 +2204,9 @@
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "dev": true,
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.4.0",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         },
         "regjsgen": {
@@ -2221,7 +2221,7 @@
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           }
         }
       }
@@ -2232,9 +2232,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -2243,8 +2243,8 @@
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-export-extensions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-export-extensions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -2253,8 +2253,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-flow": "^6.18.0",
-        "babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -2263,8 +2263,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -2273,7 +2273,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       },
       "dependencies": {
         "regenerator-transform": {
@@ -2282,9 +2282,9 @@
           "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.18.0",
-            "babel-types": "^6.19.0",
-            "private": "^0.1.6"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "private": "0.1.8"
           }
         }
       }
@@ -2295,8 +2295,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-preset-es2015": {
@@ -2305,30 +2305,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0"
       }
     },
     "babel-preset-jest": {
@@ -2337,8 +2337,8 @@
       "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^23.2.0",
-        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+        "babel-plugin-jest-hoist": "23.2.0",
+        "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
     "babel-preset-stage-1": {
@@ -2347,9 +2347,9 @@
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "^6.24.1",
-        "babel-plugin-transform-export-extensions": "^6.22.0",
-        "babel-preset-stage-2": "^6.24.1"
+        "babel-plugin-transform-class-constructor-call": "6.24.1",
+        "babel-plugin-transform-export-extensions": "6.22.0",
+        "babel-preset-stage-2": "6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -2358,10 +2358,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-plugin-transform-class-properties": "^6.24.1",
-        "babel-plugin-transform-decorators": "^6.24.1",
-        "babel-preset-stage-3": "^6.24.1"
+        "babel-plugin-syntax-dynamic-import": "6.18.0",
+        "babel-plugin-transform-class-properties": "6.24.1",
+        "babel-plugin-transform-decorators": "6.24.1",
+        "babel-preset-stage-3": "6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -2370,11 +2370,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-generator-functions": "^6.24.1",
-        "babel-plugin-transform-async-to-generator": "^6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
-        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-generator-functions": "6.24.1",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-object-rest-spread": "6.26.0"
       }
     },
     "babel-register": {
@@ -2383,13 +2383,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.10",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       },
       "dependencies": {
         "babel-core": {
@@ -2398,25 +2398,25 @@
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           }
         },
         "babylon": {
@@ -2445,8 +2445,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
@@ -2463,11 +2463,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "babylon": {
@@ -2484,15 +2484,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "babylon": {
@@ -2515,10 +2515,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "1.0.3"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -2547,13 +2547,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2562,7 +2562,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -2571,7 +2571,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2580,7 +2580,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2589,9 +2589,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -2615,7 +2615,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "big.js": {
@@ -2655,15 +2655,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.19",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "iconv-lite": {
@@ -2680,12 +2680,12 @@
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
+        "array-flatten": "2.1.1",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.2.3",
+        "multicast-dns-service-types": "1.1.0"
       }
     },
     "boolbase": {
@@ -2700,7 +2700,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2710,16 +2710,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2728,7 +2728,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2768,12 +2768,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
@@ -2782,9 +2782,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.2",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -2793,10 +2793,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-rsa": {
@@ -2805,8 +2805,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -2815,13 +2815,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.1",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.1"
       }
     },
     "browserify-zlib": {
@@ -2830,7 +2830,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.6"
       }
     },
     "browserslist": {
@@ -2839,9 +2839,9 @@
       "integrity": "sha512-kQBKB8hnq1SRfSpwHDpM1JNHAyk9fydW8hIDvndR2ijTFKIlBPEvkJkCt8JznOugdm12/YCaRgyq/sqDGz9PwA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000878",
-        "electron-to-chromium": "^1.3.61",
-        "node-releases": "^1.0.0-alpha.11"
+        "caniuse-lite": "1.0.30000880",
+        "electron-to-chromium": "1.3.61",
+        "node-releases": "1.0.0-alpha.11"
       },
       "dependencies": {
         "electron-to-chromium": {
@@ -2858,7 +2858,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer": {
@@ -2867,9 +2867,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.12",
+        "isarray": "1.0.0"
       }
     },
     "buffer-alloc": {
@@ -2878,8 +2878,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2936,19 +2936,19 @@
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.1",
-        "chownr": "^1.0.1",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "lru-cache": "^4.1.1",
-        "mississippi": "^2.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^5.2.4",
-        "unique-filename": "^1.1.0",
-        "y18n": "^4.0.0"
+        "bluebird": "3.5.1",
+        "chownr": "1.0.1",
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.3",
+        "mississippi": "2.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.2",
+        "ssri": "5.3.0",
+        "unique-filename": "1.1.0",
+        "y18n": "4.0.0"
       }
     },
     "cache-base": {
@@ -2957,15 +2957,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "cacheable-request": {
@@ -2995,9 +2995,9 @@
           "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
           "dev": true,
           "requires": {
-            "prepend-http": "^2.0.0",
-            "query-string": "^5.0.1",
-            "sort-keys": "^2.0.0"
+            "prepend-http": "2.0.0",
+            "query-string": "5.1.1",
+            "sort-keys": "2.0.0"
           }
         },
         "prepend-http": {
@@ -3012,9 +3012,9 @@
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
+            "decode-uri-component": "0.2.0",
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
           }
         },
         "sort-keys": {
@@ -3023,7 +3023,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "^1.0.0"
+            "is-plain-obj": "1.1.0"
           }
         }
       }
@@ -3046,8 +3046,8 @@
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
       }
     },
     "camelcase": {
@@ -3062,8 +3062,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -3080,10 +3080,10 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.3.6",
-        "caniuse-db": "^1.0.30000529",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000846",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -3092,8 +3092,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000846",
+            "electron-to-chromium": "1.3.48"
           }
         }
       }
@@ -3116,7 +3116,7 @@
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
       "dev": true,
       "requires": {
-        "rsvp": "^3.3.3"
+        "rsvp": "3.6.2"
       }
     },
     "caseless": {
@@ -3132,8 +3132,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "chalk": {
@@ -3142,9 +3142,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
       }
     },
     "chardet": {
@@ -3159,19 +3159,19 @@
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.1",
+        "braces": "2.3.2",
+        "fsevents": "1.2.4",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.0",
+        "lodash.debounce": "4.0.8",
+        "normalize-path": "2.1.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0",
+        "upath": "1.1.0"
       }
     },
     "chownr": {
@@ -3186,7 +3186,7 @@
       "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "ci-info": {
@@ -3201,8 +3201,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "clap": {
@@ -3211,7 +3211,7 @@
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3"
+        "chalk": "1.1.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3232,11 +3232,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "has-ansi": {
@@ -3245,7 +3245,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-ansi": {
@@ -3254,7 +3254,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -3271,10 +3271,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -3283,7 +3283,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -3294,7 +3294,7 @@
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.x"
+        "source-map": "0.5.7"
       }
     },
     "cli-cursor": {
@@ -3303,7 +3303,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
@@ -3336,7 +3336,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
+        "string-width": "1.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3351,7 +3351,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -3360,9 +3360,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -3371,7 +3371,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -3388,9 +3388,9 @@
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -3411,7 +3411,7 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "clone-stats": {
@@ -3426,9 +3426,9 @@
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "co": {
@@ -3443,7 +3443,7 @@
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
-        "q": "^1.1.2"
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -3458,8 +3458,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -3468,9 +3468,9 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2",
-        "color-convert": "^1.3.0",
-        "color-string": "^0.3.0"
+        "clone": "1.0.4",
+        "color-convert": "1.9.1",
+        "color-string": "0.3.0"
       }
     },
     "color-convert": {
@@ -3479,7 +3479,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -3494,7 +3494,7 @@
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "1.1.3"
       }
     },
     "colormin": {
@@ -3503,9 +3503,9 @@
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
-        "color": "^0.11.0",
+        "color": "0.11.4",
         "css-color-names": "0.0.4",
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "colors": {
@@ -3520,7 +3520,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -3553,7 +3553,7 @@
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "dev": true,
       "requires": {
-        "mime-db": ">= 1.34.0 < 2"
+        "mime-db": "1.36.0"
       }
     },
     "compression": {
@@ -3562,13 +3562,13 @@
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.14",
+        "compressible": "2.0.14",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "1.0.1",
         "safe-buffer": "5.1.2",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       }
     },
     "concat-map": {
@@ -3583,10 +3583,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "concurrently": {
@@ -3595,15 +3595,15 @@
       "integrity": "sha512-/+ugz+gwFSEfTGUxn0KHkY+19XPRTXR8+7oUK/HxgiN1n7FjeJmkrbSiXAJfyQ0zORgJYPaenmymwon51YXH9Q==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
+        "chalk": "2.4.1",
         "commander": "2.6.0",
-        "date-fns": "^1.23.0",
-        "lodash": "^4.5.1",
-        "read-pkg": "^3.0.0",
+        "date-fns": "1.29.0",
+        "lodash": "4.17.10",
+        "read-pkg": "3.0.0",
         "rx": "2.3.24",
-        "spawn-command": "^0.0.2-1",
-        "supports-color": "^3.2.3",
-        "tree-kill": "^1.1.0"
+        "spawn-command": "0.0.2-1",
+        "supports-color": "3.2.3",
+        "tree-kill": "1.2.0"
       },
       "dependencies": {
         "commander": {
@@ -3624,7 +3624,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -3641,7 +3641,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "^0.1.4"
+        "date-now": "0.1.4"
       }
     },
     "constants-browserify": {
@@ -3686,12 +3686,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
       }
     },
     "copy-descriptor": {
@@ -3718,9 +3718,9 @@
       "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
       "dev": true,
       "requires": {
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0"
+        "is-directory": "0.3.1",
+        "js-yaml": "3.12.0",
+        "parse-json": "4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -3735,8 +3735,8 @@
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
           }
         }
       }
@@ -3747,8 +3747,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.1"
       }
     },
     "create-hash": {
@@ -3757,11 +3757,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -3770,12 +3770,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "cross-spawn": {
@@ -3784,11 +3784,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.5.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-browserify": {
@@ -3797,17 +3797,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.16",
+        "public-encrypt": "4.0.2",
+        "randombytes": "2.0.6",
+        "randomfill": "1.0.4"
       }
     },
     "css-color-names": {
@@ -3822,20 +3822,20 @@
       "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "css-selector-tokenizer": "^0.7.0",
-        "cssnano": "^3.10.0",
-        "icss-utils": "^2.1.0",
-        "loader-utils": "^1.0.2",
-        "lodash.camelcase": "^4.3.0",
-        "object-assign": "^4.1.1",
-        "postcss": "^5.0.6",
-        "postcss-modules-extract-imports": "^1.2.0",
-        "postcss-modules-local-by-default": "^1.2.0",
-        "postcss-modules-scope": "^1.1.0",
-        "postcss-modules-values": "^1.3.0",
-        "postcss-value-parser": "^3.3.0",
-        "source-list-map": "^2.0.0"
+        "babel-code-frame": "6.26.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "icss-utils": "2.1.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-modules-extract-imports": "1.2.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "postcss-value-parser": "3.3.0",
+        "source-list-map": "2.0.0"
       }
     },
     "css-select": {
@@ -3844,10 +3844,10 @@
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
         "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "nth-check": "1.0.1"
       }
     },
     "css-selector-tokenizer": {
@@ -3856,9 +3856,9 @@
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "dev": true,
       "requires": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
       },
       "dependencies": {
         "jsesc": {
@@ -3873,9 +3873,9 @@
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.4.0",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         },
         "regjsgen": {
@@ -3890,7 +3890,7 @@
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           }
         }
       }
@@ -3913,38 +3913,38 @@
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
-        "autoprefixer": "^6.3.1",
-        "decamelize": "^1.1.2",
-        "defined": "^1.0.0",
-        "has": "^1.0.1",
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.14",
-        "postcss-calc": "^5.2.0",
-        "postcss-colormin": "^2.1.8",
-        "postcss-convert-values": "^2.3.4",
-        "postcss-discard-comments": "^2.0.4",
-        "postcss-discard-duplicates": "^2.0.1",
-        "postcss-discard-empty": "^2.0.1",
-        "postcss-discard-overridden": "^0.1.1",
-        "postcss-discard-unused": "^2.2.1",
-        "postcss-filter-plugins": "^2.0.0",
-        "postcss-merge-idents": "^2.1.5",
-        "postcss-merge-longhand": "^2.0.1",
-        "postcss-merge-rules": "^2.0.3",
-        "postcss-minify-font-values": "^1.0.2",
-        "postcss-minify-gradients": "^1.0.1",
-        "postcss-minify-params": "^1.0.4",
-        "postcss-minify-selectors": "^2.0.4",
-        "postcss-normalize-charset": "^1.1.0",
-        "postcss-normalize-url": "^3.0.7",
-        "postcss-ordered-values": "^2.1.0",
-        "postcss-reduce-idents": "^2.2.2",
-        "postcss-reduce-initial": "^1.0.0",
-        "postcss-reduce-transforms": "^1.0.3",
-        "postcss-svgo": "^2.1.1",
-        "postcss-unique-selectors": "^2.0.2",
-        "postcss-value-parser": "^3.2.3",
-        "postcss-zindex": "^2.0.1"
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.3",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
       }
     },
     "csso": {
@@ -3953,8 +3953,8 @@
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
       "requires": {
-        "clap": "^1.0.9",
-        "source-map": "^0.5.3"
+        "clap": "1.2.3",
+        "source-map": "0.5.7"
       }
     },
     "cssom": {
@@ -3969,7 +3969,7 @@
       "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
       "dev": true,
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "0.3.4"
       }
     },
     "currently-unhandled": {
@@ -3978,7 +3978,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "cyclist": {
@@ -3999,7 +3999,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-urls": {
@@ -4008,9 +4008,9 @@
       "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.0",
-        "whatwg-mimetype": "^2.1.0",
-        "whatwg-url": "^7.0.0"
+        "abab": "2.0.0",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "7.0.0"
       },
       "dependencies": {
         "whatwg-url": {
@@ -4019,9 +4019,9 @@
           "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
           "dev": true,
           "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
           }
         }
       }
@@ -4071,7 +4071,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "dedent": {
@@ -4104,7 +4104,7 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "^3.0.0"
+        "strip-bom": "3.0.0"
       }
     },
     "define-properties": {
@@ -4113,8 +4113,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "define-property": {
@@ -4123,8 +4123,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -4133,7 +4133,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4142,7 +4142,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4151,9 +4151,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -4170,12 +4170,12 @@
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "globby": {
@@ -4184,11 +4184,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "glob": "7.1.3",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           },
           "dependencies": {
             "pify": {
@@ -4219,8 +4219,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "destroy": {
@@ -4241,7 +4241,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-newline": {
@@ -4268,9 +4268,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.0.6"
       }
     },
     "dir-glob": {
@@ -4279,8 +4279,8 @@
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       }
     },
     "dns-equal": {
@@ -4295,8 +4295,8 @@
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.2"
       }
     },
     "dns-txt": {
@@ -4305,7 +4305,7 @@
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
-        "buffer-indexof": "^1.0.0"
+        "buffer-indexof": "1.1.1"
       }
     },
     "dom-converter": {
@@ -4314,7 +4314,7 @@
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
       "requires": {
-        "utila": "~0.3"
+        "utila": "0.3.3"
       },
       "dependencies": {
         "utila": {
@@ -4331,8 +4331,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -4361,7 +4361,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "^4.0.2"
+        "webidl-conversions": "4.0.2"
       }
     },
     "domhandler": {
@@ -4370,7 +4370,7 @@
       "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -4379,8 +4379,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "duplexer3": {
@@ -4395,10 +4395,10 @@
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -4408,8 +4408,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "editions": {
@@ -4448,13 +4448,13 @@
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.5",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emojis-list": {
@@ -4475,7 +4475,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "0.4.24"
       }
     },
     "end-of-stream": {
@@ -4484,7 +4484,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -4493,9 +4493,9 @@
       "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "tapable": "^1.0.0"
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "tapable": "1.0.0"
       }
     },
     "entities": {
@@ -4516,7 +4516,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error": {
@@ -4525,8 +4525,8 @@
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dev": true,
       "requires": {
-        "string-template": "~0.2.1",
-        "xtend": "~4.0.0"
+        "string-template": "0.2.1",
+        "xtend": "4.0.1"
       }
     },
     "error-ex": {
@@ -4535,7 +4535,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -4544,11 +4544,11 @@
       "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -4557,9 +4557,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "escape-html": {
@@ -4580,11 +4580,11 @@
       "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -4608,8 +4608,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "esprima": {
@@ -4624,7 +4624,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -4663,7 +4663,7 @@
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "dev": true,
       "requires": {
-        "original": ">=0.0.5"
+        "original": "1.0.2"
       }
     },
     "evp_bytestokey": {
@@ -4672,8 +4672,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.2"
       }
     },
     "exec-sh": {
@@ -4682,7 +4682,7 @@
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "dev": true,
       "requires": {
-        "merge": "^1.2.0"
+        "merge": "1.2.0"
       }
     },
     "execa": {
@@ -4691,13 +4691,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -4706,9 +4706,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         }
       }
@@ -4731,13 +4731,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -4746,7 +4746,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -4755,7 +4755,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -4766,7 +4766,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       },
       "dependencies": {
         "fill-range": {
@@ -4775,11 +4775,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "3.1.0",
+            "repeat-element": "1.1.3",
+            "repeat-string": "1.6.1"
           }
         },
         "is-number": {
@@ -4788,7 +4788,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isobject": {
@@ -4806,7 +4806,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4817,7 +4817,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "expect": {
@@ -4826,12 +4826,12 @@
       "integrity": "sha512-aG083W63tBloy8YgafWuC44EakjYe0Q6Mg35aujBPvyNU38DvLat9BVzOihNP2NZDLaCJiFNe0vejbtO6knnlA==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "jest-diff": "^23.5.0",
-        "jest-get-type": "^22.1.0",
-        "jest-matcher-utils": "^23.5.0",
-        "jest-message-util": "^23.4.0",
-        "jest-regex-util": "^23.3.0"
+        "ansi-styles": "3.2.1",
+        "jest-diff": "23.5.0",
+        "jest-get-type": "22.4.3",
+        "jest-matcher-utils": "23.5.0",
+        "jest-message-util": "23.4.0",
+        "jest-regex-util": "23.3.0"
       }
     },
     "express": {
@@ -4840,36 +4840,36 @@
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.1",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -4898,8 +4898,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4908,7 +4908,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4919,9 +4919,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
-        "tmp": "^0.0.33"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -4930,14 +4930,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -4946,7 +4946,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -4955,7 +4955,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -4964,7 +4964,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4973,7 +4973,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4982,9 +4982,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -5007,12 +5007,12 @@
       "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.0.1",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.1",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.1",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.2",
+        "micromatch": "3.1.10"
       }
     },
     "fast-json-stable-stringify": {
@@ -5039,7 +5039,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": ">=0.5.1"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -5048,7 +5048,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fbjs": {
@@ -5057,13 +5057,13 @@
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "dev": true,
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.18"
       }
     },
     "figures": {
@@ -5072,7 +5072,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "filename-regex": {
@@ -5087,8 +5087,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
+        "glob": "7.1.3",
+        "minimatch": "3.0.4"
       }
     },
     "fill-range": {
@@ -5097,10 +5097,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5109,7 +5109,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -5121,12 +5121,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       }
     },
     "find-cache-dir": {
@@ -5135,9 +5135,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
-        "pkg-dir": "^2.0.0"
+        "commondir": "1.0.1",
+        "make-dir": "1.3.0",
+        "pkg-dir": "2.0.0"
       }
     },
     "find-parent-dir": {
@@ -5152,7 +5152,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "first-chunk-stream": {
@@ -5161,7 +5161,7 @@
       "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "flatten": {
@@ -5182,8 +5182,8 @@
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "follow-redirects": {
@@ -5192,7 +5192,7 @@
       "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -5218,7 +5218,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -5239,9 +5239,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.20"
       }
     },
     "forwarded": {
@@ -5256,7 +5256,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -5271,8 +5271,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "fs-readdir-recursive": {
@@ -5287,10 +5287,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.6"
       }
     },
     "fs.realpath": {
@@ -5306,8 +5306,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.11.0",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5333,8 +5333,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -5347,7 +5347,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5411,7 +5411,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -5426,14 +5426,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -5442,12 +5442,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -5462,7 +5462,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -5471,7 +5471,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -5480,8 +5480,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -5500,7 +5500,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -5514,7 +5514,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -5527,8 +5527,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -5537,7 +5537,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -5560,9 +5560,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5571,16 +5571,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -5589,8 +5589,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -5605,8 +5605,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -5615,10 +5615,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -5637,7 +5637,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -5658,8 +5658,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -5680,10 +5680,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5700,13 +5700,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -5715,7 +5715,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -5758,9 +5758,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -5769,7 +5769,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -5777,7 +5777,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -5792,13 +5792,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -5813,7 +5813,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -5870,7 +5870,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "gh-got": {
@@ -5879,8 +5879,8 @@
       "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
       "dev": true,
       "requires": {
-        "got": "^7.0.0",
-        "is-plain-obj": "^1.1.0"
+        "got": "7.1.0",
+        "is-plain-obj": "1.1.0"
       },
       "dependencies": {
         "got": {
@@ -5889,20 +5889,20 @@
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "dev": true,
           "requires": {
-            "decompress-response": "^3.2.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "isurl": "^1.0.0-alpha5",
-            "lowercase-keys": "^1.0.0",
-            "p-cancelable": "^0.3.0",
-            "p-timeout": "^1.1.1",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "url-parse-lax": "^1.0.0",
-            "url-to-options": "^1.0.1"
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-plain-obj": "1.1.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.1",
+            "p-cancelable": "0.3.0",
+            "p-timeout": "1.2.1",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "1.0.0",
+            "url-to-options": "1.0.1"
           }
         },
         "p-cancelable": {
@@ -5917,7 +5917,7 @@
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "dev": true,
           "requires": {
-            "p-finally": "^1.0.0"
+            "p-finally": "1.0.0"
           }
         },
         "url-parse-lax": {
@@ -5926,7 +5926,7 @@
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         }
       }
@@ -5937,7 +5937,7 @@
       "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
       "dev": true,
       "requires": {
-        "gh-got": "^6.0.0"
+        "gh-got": "6.0.0"
       }
     },
     "glob": {
@@ -5946,12 +5946,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-all": {
@@ -5960,8 +5960,8 @@
       "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5",
-        "yargs": "~1.2.6"
+        "glob": "7.1.3",
+        "yargs": "1.2.6"
       },
       "dependencies": {
         "minimist": {
@@ -5976,7 +5976,7 @@
           "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
           "dev": true,
           "requires": {
-            "minimist": "^0.1.0"
+            "minimist": "0.1.0"
           }
         }
       }
@@ -5987,8 +5987,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -5997,7 +5997,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -6012,7 +6012,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -6023,8 +6023,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       },
       "dependencies": {
         "is-glob": {
@@ -6033,7 +6033,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -6050,9 +6050,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -6061,11 +6061,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       }
     },
     "globals": {
@@ -6080,13 +6080,13 @@
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "array-union": "1.0.2",
+        "dir-glob": "2.0.0",
+        "fast-glob": "2.2.2",
+        "glob": "7.1.3",
+        "ignore": "3.3.10",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       },
       "dependencies": {
         "slash": {
@@ -6103,23 +6103,23 @@
       "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
+        "@sindresorhus/is": "0.7.0",
+        "cacheable-request": "2.1.4",
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "into-stream": "3.1.0",
+        "is-retry-allowed": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.1",
+        "mimic-response": "1.0.1",
+        "p-cancelable": "0.4.1",
+        "p-timeout": "2.0.1",
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "3.0.0",
+        "url-to-options": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -6134,7 +6134,7 @@
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.2"
+        "lodash": "4.17.10"
       }
     },
     "growly": {
@@ -6155,10 +6155,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
       },
       "dependencies": {
         "camelcase": {
@@ -6175,8 +6175,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
         },
@@ -6186,7 +6186,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "uglify-js": {
@@ -6196,9 +6196,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -6224,9 +6224,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
             "window-size": "0.1.0"
           }
         }
@@ -6244,8 +6244,8 @@
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -6254,10 +6254,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
           }
         },
         "fast-deep-equal": {
@@ -6274,7 +6274,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -6283,7 +6283,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6318,7 +6318,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-value": {
@@ -6327,9 +6327,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -6338,8 +6338,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6348,7 +6348,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6359,8 +6359,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -6369,8 +6369,8 @@
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "he": {
@@ -6385,9 +6385,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.5",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "home-or-tmp": {
@@ -6396,8 +6396,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -6406,7 +6406,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -6421,10 +6421,10 @@
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
+        "inherits": "2.0.3",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "wbuf": "1.7.3"
       }
     },
     "html-comment-regex": {
@@ -6439,7 +6439,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.1"
+        "whatwg-encoding": "1.0.4"
       }
     },
     "html-entities": {
@@ -6454,13 +6454,13 @@
       "integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
       "dev": true,
       "requires": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.1.x",
-        "commander": "2.15.x",
-        "he": "1.1.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.3.x"
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.11",
+        "commander": "2.15.1",
+        "he": "1.1.1",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.3.27"
       }
     },
     "html-webpack-plugin": {
@@ -6469,12 +6469,12 @@
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
-        "html-minifier": "^3.2.3",
-        "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
-        "pretty-error": "^2.0.2",
-        "tapable": "^1.0.0",
-        "toposort": "^1.0.0",
+        "html-minifier": "3.5.16",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.10",
+        "pretty-error": "2.1.1",
+        "tapable": "1.0.0",
+        "toposort": "1.0.7",
         "util.promisify": "1.0.0"
       },
       "dependencies": {
@@ -6484,10 +6484,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
           }
         }
       }
@@ -6498,10 +6498,10 @@
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "dev": true,
       "requires": {
-        "domelementtype": "1",
-        "domhandler": "2.1",
-        "domutils": "1.1",
-        "readable-stream": "1.0"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.1.0",
+        "domutils": "1.1.6",
+        "readable-stream": "1.0.34"
       },
       "dependencies": {
         "domutils": {
@@ -6510,7 +6510,7 @@
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "dev": true,
           "requires": {
-            "domelementtype": "1"
+            "domelementtype": "1.3.0"
           }
         },
         "isarray": {
@@ -6525,10 +6525,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -6557,10 +6557,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -6575,9 +6575,9 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
+        "eventemitter3": "3.1.0",
+        "follow-redirects": "1.5.7",
+        "requires-port": "1.0.0"
       }
     },
     "http-proxy-middleware": {
@@ -6586,10 +6586,10 @@
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {
-        "http-proxy": "^1.16.2",
-        "is-glob": "^4.0.0",
-        "lodash": "^4.17.5",
-        "micromatch": "^3.1.9"
+        "http-proxy": "1.17.0",
+        "is-glob": "4.0.0",
+        "lodash": "4.17.10",
+        "micromatch": "3.1.10"
       }
     },
     "http-signature": {
@@ -6598,9 +6598,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "https-browserify": {
@@ -6615,16 +6615,16 @@
       "integrity": "sha512-9TdkUpBeEOjz0AnFdUN4i3w8kEbOsVs9/WSeJqWLq2OO6bcKQhVW64Zi+pVd/AMRLpN3QTINb6ZXiELczvdmqQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^5.0.6",
-        "execa": "^0.9.0",
-        "find-up": "^3.0.0",
-        "get-stdin": "^6.0.0",
-        "is-ci": "^1.2.1",
-        "pkg-dir": "^3.0.0",
-        "please-upgrade-node": "^3.1.1",
-        "read-pkg": "^4.0.1",
-        "run-node": "^1.0.0",
-        "slash": "^2.0.0"
+        "cosmiconfig": "5.0.6",
+        "execa": "0.9.0",
+        "find-up": "3.0.0",
+        "get-stdin": "6.0.0",
+        "is-ci": "1.2.1",
+        "pkg-dir": "3.0.0",
+        "please-upgrade-node": "3.1.1",
+        "read-pkg": "4.0.1",
+        "run-node": "1.0.0",
+        "slash": "2.0.0"
       },
       "dependencies": {
         "ci-info": {
@@ -6639,9 +6639,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "execa": {
@@ -6650,13 +6650,13 @@
           "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "find-up": {
@@ -6665,7 +6665,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "get-stdin": {
@@ -6680,7 +6680,7 @@
           "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
-            "ci-info": "^1.5.0"
+            "ci-info": "1.6.0"
           }
         },
         "locate-path": {
@@ -6689,8 +6689,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -6699,7 +6699,7 @@
           "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.0.0"
           }
         },
         "p-locate": {
@@ -6708,7 +6708,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.0.0"
           }
         },
         "p-try": {
@@ -6723,7 +6723,7 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0"
+            "find-up": "3.0.0"
           }
         },
         "read-pkg": {
@@ -6732,9 +6732,9 @@
           "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
           "dev": true,
           "requires": {
-            "normalize-package-data": "^2.3.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0"
+            "normalize-package-data": "2.4.0",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0"
           }
         }
       }
@@ -6745,7 +6745,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "icss-replace-symbols": {
@@ -6760,7 +6760,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "postcss": {
@@ -6769,9 +6769,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -6806,8 +6806,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -6822,7 +6822,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexes-of": {
@@ -6843,8 +6843,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -6865,19 +6865,19 @@
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
-        "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.2.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "5.5.11",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
       }
     },
     "internal-ip": {
@@ -6886,7 +6886,7 @@
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
       "dev": true,
       "requires": {
-        "meow": "^3.3.0"
+        "meow": "3.7.0"
       }
     },
     "interpret": {
@@ -6901,8 +6901,8 @@
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
       }
     },
     "invariant": {
@@ -6911,7 +6911,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -6944,7 +6944,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6953,7 +6953,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -6970,7 +6970,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -6985,7 +6985,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -7000,7 +7000,7 @@
       "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.3.0"
+        "ci-info": "1.4.0"
       }
     },
     "is-data-descriptor": {
@@ -7009,7 +7009,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -7018,7 +7018,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -7035,9 +7035,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -7066,7 +7066,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -7087,7 +7087,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -7108,7 +7108,7 @@
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "2.1.1"
       }
     },
     "is-number": {
@@ -7117,7 +7117,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -7126,7 +7126,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -7149,7 +7149,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "^1.1.0"
+        "symbol-observable": "1.2.0"
       },
       "dependencies": {
         "symbol-observable": {
@@ -7172,7 +7172,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -7181,7 +7181,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -7196,7 +7196,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -7223,7 +7223,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-regexp": {
@@ -7244,7 +7244,7 @@
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
       "dev": true,
       "requires": {
-        "scoped-regex": "^1.0.0"
+        "scoped-regex": "1.0.0"
       }
     },
     "is-stream": {
@@ -7259,7 +7259,7 @@
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "dev": true,
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.1"
       }
     },
     "is-symbol": {
@@ -7304,7 +7304,7 @@
       "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
       "dev": true,
       "requires": {
-        "buffer-alloc": "^1.2.0"
+        "buffer-alloc": "1.2.0"
       }
     },
     "isexe": {
@@ -7325,8 +7325,8 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -7341,18 +7341,18 @@
       "integrity": "sha512-luJDnB1uJ5Qsg/WwusGfNXayQ4598yDgW5S0nUS85T576m1LVJzSqLrCDULkT6sTQXVKHa54093gNuCKumMCjQ==",
       "dev": true,
       "requires": {
-        "async": "^2.1.4",
-        "compare-versions": "^3.1.0",
-        "fileset": "^2.0.2",
-        "istanbul-lib-coverage": "^1.2.0",
-        "istanbul-lib-hook": "^1.2.0",
-        "istanbul-lib-instrument": "^2.1.0",
-        "istanbul-lib-report": "^1.1.4",
-        "istanbul-lib-source-maps": "^1.2.5",
-        "istanbul-reports": "^1.4.1",
-        "js-yaml": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "once": "^1.4.0"
+        "async": "2.6.1",
+        "compare-versions": "3.3.1",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.2.1",
+        "istanbul-lib-instrument": "2.3.2",
+        "istanbul-lib-report": "1.1.4",
+        "istanbul-lib-source-maps": "1.2.5",
+        "istanbul-reports": "1.5.0",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -7371,10 +7371,10 @@
           "dev": true,
           "requires": {
             "@babel/types": "7.0.0-beta.51",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.5",
-            "source-map": "^0.5.0",
-            "trim-right": "^1.0.1"
+            "jsesc": "2.5.1",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
           }
         },
         "@babel/helper-function-name": {
@@ -7412,9 +7412,9 @@
           "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
           "dev": true,
           "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "@babel/parser": {
@@ -7432,7 +7432,7 @@
             "@babel/code-frame": "7.0.0-beta.51",
             "@babel/parser": "7.0.0-beta.51",
             "@babel/types": "7.0.0-beta.51",
-            "lodash": "^4.17.5"
+            "lodash": "4.17.10"
           }
         },
         "@babel/traverse": {
@@ -7447,10 +7447,10 @@
             "@babel/helper-split-export-declaration": "7.0.0-beta.51",
             "@babel/parser": "7.0.0-beta.51",
             "@babel/types": "7.0.0-beta.51",
-            "debug": "^3.1.0",
-            "globals": "^11.1.0",
-            "invariant": "^2.2.0",
-            "lodash": "^4.17.5"
+            "debug": "3.1.0",
+            "globals": "11.7.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
           }
         },
         "@babel/types": {
@@ -7459,9 +7459,9 @@
           "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.5",
-            "to-fast-properties": "^2.0.0"
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
           }
         },
         "async": {
@@ -7470,7 +7470,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.10"
           }
         },
         "debug": {
@@ -7493,8 +7493,8 @@
             "@babel/template": "7.0.0-beta.51",
             "@babel/traverse": "7.0.0-beta.51",
             "@babel/types": "7.0.0-beta.51",
-            "istanbul-lib-coverage": "^2.0.1",
-            "semver": "^5.5.0"
+            "istanbul-lib-coverage": "2.0.1",
+            "semver": "5.5.1"
           },
           "dependencies": {
             "istanbul-lib-coverage": {
@@ -7519,7 +7519,7 @@
       "integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
       "dev": true,
       "requires": {
-        "append-transform": "^1.0.0"
+        "append-transform": "1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -7528,13 +7528,13 @@
       "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
-        "babel-generator": "^6.18.0",
-        "babel-template": "^6.16.0",
-        "babel-traverse": "^6.18.0",
-        "babel-types": "^6.18.0",
-        "babylon": "^6.18.0",
-        "istanbul-lib-coverage": "^1.2.0",
-        "semver": "^5.3.0"
+        "babel-generator": "6.26.1",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "semver": "5.5.1"
       },
       "dependencies": {
         "babylon": {
@@ -7551,10 +7551,10 @@
       "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "path-parse": "^1.0.5",
-        "supports-color": "^3.1.2"
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "path-parse": "1.0.6",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "has-flag": {
@@ -7569,7 +7569,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -7580,11 +7580,11 @@
       "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "istanbul-lib-coverage": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.1",
-        "source-map": "^0.5.3"
+        "debug": "3.1.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -7604,7 +7604,7 @@
       "integrity": "sha512-HeZG0WHretI9FXBni5wZ9DOgNziqDCEwetxnme5k1Vv5e81uTqcsy3fMH99gXGDGKr1ea87TyGseDMa2h4HEUA==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.0.11"
+        "handlebars": "4.0.11"
       }
     },
     "istextorbinary": {
@@ -7613,9 +7613,9 @@
       "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
       "dev": true,
       "requires": {
-        "binaryextensions": "2",
-        "editions": "^1.3.3",
-        "textextensions": "2"
+        "binaryextensions": "2.1.1",
+        "editions": "1.3.4",
+        "textextensions": "2.2.0"
       }
     },
     "isurl": {
@@ -7624,8 +7624,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "jest": {
@@ -7634,8 +7634,8 @@
       "integrity": "sha512-+X3Fk4rD8dTnHoIxHJymZthbtYllvSOnXAApQltvyLkHsv+fqyC/SZptUJDbXkFsqZJyyIXMySkdzerz3fv4oQ==",
       "dev": true,
       "requires": {
-        "import-local": "^1.0.0",
-        "jest-cli": "^23.5.0"
+        "import-local": "1.0.0",
+        "jest-cli": "23.5.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -7644,7 +7644,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -7659,9 +7659,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "expand-brackets": {
@@ -7670,7 +7670,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -7679,7 +7679,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -7694,7 +7694,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "jest-cli": {
@@ -7703,42 +7703,42 @@
           "integrity": "sha512-Kxi2QH8s6NkpPgboza/plpmQ2bjUQ+MwYv7vM5rDwJz/x+NB4YoLXFikPXLWNP0JuYpMvYwITKneFljnNKhq2Q==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.1",
-            "exit": "^0.1.2",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "import-local": "^1.0.0",
-            "is-ci": "^1.0.10",
-            "istanbul-api": "^1.3.1",
-            "istanbul-lib-coverage": "^1.2.0",
-            "istanbul-lib-instrument": "^1.10.1",
-            "istanbul-lib-source-maps": "^1.2.4",
-            "jest-changed-files": "^23.4.2",
-            "jest-config": "^23.5.0",
-            "jest-environment-jsdom": "^23.4.0",
-            "jest-get-type": "^22.1.0",
-            "jest-haste-map": "^23.5.0",
-            "jest-message-util": "^23.4.0",
-            "jest-regex-util": "^23.3.0",
-            "jest-resolve-dependencies": "^23.5.0",
-            "jest-runner": "^23.5.0",
-            "jest-runtime": "^23.5.0",
-            "jest-snapshot": "^23.5.0",
-            "jest-util": "^23.4.0",
-            "jest-validate": "^23.5.0",
-            "jest-watcher": "^23.4.0",
-            "jest-worker": "^23.2.0",
-            "micromatch": "^2.3.11",
-            "node-notifier": "^5.2.1",
-            "prompts": "^0.1.9",
-            "realpath-native": "^1.0.0",
-            "rimraf": "^2.5.4",
-            "slash": "^1.0.0",
-            "string-length": "^2.0.0",
-            "strip-ansi": "^4.0.0",
-            "which": "^1.2.12",
-            "yargs": "^11.0.0"
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "exit": "0.1.2",
+            "glob": "7.1.3",
+            "graceful-fs": "4.1.11",
+            "import-local": "1.0.0",
+            "is-ci": "1.2.0",
+            "istanbul-api": "1.3.6",
+            "istanbul-lib-coverage": "1.2.0",
+            "istanbul-lib-instrument": "1.10.1",
+            "istanbul-lib-source-maps": "1.2.5",
+            "jest-changed-files": "23.4.2",
+            "jest-config": "23.5.0",
+            "jest-environment-jsdom": "23.4.0",
+            "jest-get-type": "22.4.3",
+            "jest-haste-map": "23.5.0",
+            "jest-message-util": "23.4.0",
+            "jest-regex-util": "23.3.0",
+            "jest-resolve-dependencies": "23.5.0",
+            "jest-runner": "23.5.0",
+            "jest-runtime": "23.5.0",
+            "jest-snapshot": "23.5.0",
+            "jest-util": "23.4.0",
+            "jest-validate": "23.5.0",
+            "jest-watcher": "23.4.0",
+            "jest-worker": "23.2.0",
+            "micromatch": "2.3.11",
+            "node-notifier": "5.2.1",
+            "prompts": "0.1.14",
+            "realpath-native": "1.0.1",
+            "rimraf": "2.6.2",
+            "slash": "1.0.0",
+            "string-length": "2.0.0",
+            "strip-ansi": "4.0.0",
+            "which": "1.3.1",
+            "yargs": "11.1.0"
           }
         },
         "kind-of": {
@@ -7747,7 +7747,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -7756,19 +7756,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "slash": {
@@ -7785,7 +7785,7 @@
       "integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
       "dev": true,
       "requires": {
-        "throat": "^4.0.0"
+        "throat": "4.1.0"
       }
     },
     "jest-config": {
@@ -7794,20 +7794,20 @@
       "integrity": "sha512-JENhQpLaVwXWPLUkhPYgIfecHKsU8GR1vj79rS4n0LSRsHx/U2wItZKoKAd5vtt2J58JPxRq4XheG79jd4fI7Q==",
       "dev": true,
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-jest": "^23.4.2",
-        "chalk": "^2.0.1",
-        "glob": "^7.1.1",
-        "jest-environment-jsdom": "^23.4.0",
-        "jest-environment-node": "^23.4.0",
-        "jest-get-type": "^22.1.0",
-        "jest-jasmine2": "^23.5.0",
-        "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.5.0",
-        "jest-util": "^23.4.0",
-        "jest-validate": "^23.5.0",
-        "micromatch": "^2.3.11",
-        "pretty-format": "^23.5.0"
+        "babel-core": "6.26.3",
+        "babel-jest": "23.4.2",
+        "chalk": "2.4.1",
+        "glob": "7.1.3",
+        "jest-environment-jsdom": "23.4.0",
+        "jest-environment-node": "23.4.0",
+        "jest-get-type": "22.4.3",
+        "jest-jasmine2": "23.5.0",
+        "jest-regex-util": "23.3.0",
+        "jest-resolve": "23.5.0",
+        "jest-util": "23.4.0",
+        "jest-validate": "23.5.0",
+        "micromatch": "2.3.11",
+        "pretty-format": "23.5.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -7816,7 +7816,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -7831,25 +7831,25 @@
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           }
         },
         "babylon": {
@@ -7864,9 +7864,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "expand-brackets": {
@@ -7875,7 +7875,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -7884,7 +7884,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -7899,7 +7899,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -7908,7 +7908,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -7917,19 +7917,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "slash": {
@@ -7946,10 +7946,10 @@
       "integrity": "sha512-Miz8GakJIz443HkGpVOAyHQgSYqcgs2zQmDJl4oV7DYrFotchdoQvxceF6LhfpRBV1LOUGcFk5Dd/ffSXVwMsA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "diff": "^3.2.0",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.5.0"
+        "chalk": "2.4.1",
+        "diff": "3.5.0",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.5.0"
       }
     },
     "jest-docblock": {
@@ -7958,7 +7958,7 @@
       "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
       "dev": true,
       "requires": {
-        "detect-newline": "^2.1.0"
+        "detect-newline": "2.1.0"
       }
     },
     "jest-each": {
@@ -7967,8 +7967,8 @@
       "integrity": "sha512-8BgebQgAJmWXpYp4Qt9l3cn1Xei0kZ7JL4cs/NXh7750ATlPGzRRYbutFVJTk5B/Lt3mjHP3G3tLQLyBOCSHGA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "pretty-format": "^23.5.0"
+        "chalk": "2.4.1",
+        "pretty-format": "23.5.0"
       }
     },
     "jest-environment-jsdom": {
@@ -7977,9 +7977,9 @@
       "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
       "dev": true,
       "requires": {
-        "jest-mock": "^23.2.0",
-        "jest-util": "^23.4.0",
-        "jsdom": "^11.5.1"
+        "jest-mock": "23.2.0",
+        "jest-util": "23.4.0",
+        "jsdom": "11.12.0"
       }
     },
     "jest-environment-node": {
@@ -7988,14 +7988,15 @@
       "integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
       "dev": true,
       "requires": {
-        "jest-mock": "^23.2.0",
-        "jest-util": "^23.4.0"
+        "jest-mock": "23.2.0",
+        "jest-util": "23.4.0"
       }
     },
     "jest-get-type": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
     },
     "jest-haste-map": {
       "version": "23.5.0",
@@ -8003,14 +8004,14 @@
       "integrity": "sha512-bt9Swigb6KZ6ZQq/fQDUwdUeHenVvZ6G/lKwJjwRGp+Fap8D4B3bND3FaeJg7vXVsLX8hXshRArbVxLop/5wLw==",
       "dev": true,
       "requires": {
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "invariant": "^2.2.4",
-        "jest-docblock": "^23.2.0",
-        "jest-serializer": "^23.0.1",
-        "jest-worker": "^23.2.0",
-        "micromatch": "^2.3.11",
-        "sane": "^2.0.0"
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "invariant": "2.2.4",
+        "jest-docblock": "23.2.0",
+        "jest-serializer": "23.0.1",
+        "jest-worker": "23.2.0",
+        "micromatch": "2.3.11",
+        "sane": "2.5.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -8019,7 +8020,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -8034,9 +8035,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "expand-brackets": {
@@ -8045,7 +8046,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -8054,7 +8055,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -8069,7 +8070,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -8078,7 +8079,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -8087,19 +8088,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         }
       }
@@ -8110,18 +8111,18 @@
       "integrity": "sha512-xMgvDUvgqKpilsGnneC9Qr+uIlROxKI3UoJcHZeUlu6AKpQyEkGh0hKbfM0NaEjX5sy7WeFQEhcp/AiWlHcc0A==",
       "dev": true,
       "requires": {
-        "babel-traverse": "^6.0.0",
-        "chalk": "^2.0.1",
-        "co": "^4.6.0",
-        "expect": "^23.5.0",
-        "is-generator-fn": "^1.0.0",
-        "jest-diff": "^23.5.0",
-        "jest-each": "^23.5.0",
-        "jest-matcher-utils": "^23.5.0",
-        "jest-message-util": "^23.4.0",
-        "jest-snapshot": "^23.5.0",
-        "jest-util": "^23.4.0",
-        "pretty-format": "^23.5.0"
+        "babel-traverse": "6.26.0",
+        "chalk": "2.4.1",
+        "co": "4.6.0",
+        "expect": "23.5.0",
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "23.5.0",
+        "jest-each": "23.5.0",
+        "jest-matcher-utils": "23.5.0",
+        "jest-message-util": "23.4.0",
+        "jest-snapshot": "23.5.0",
+        "jest-util": "23.4.0",
+        "pretty-format": "23.5.0"
       }
     },
     "jest-leak-detector": {
@@ -8130,7 +8131,7 @@
       "integrity": "sha512-40VsHQCIEslxg91Zg5NiZGtPeWSBLXiD6Ww+lhHlIF6u8uSQ+xgiD6NbWHFOYs1VBRI+V/ym7Q1aOtVg9tqMzQ==",
       "dev": true,
       "requires": {
-        "pretty-format": "^23.5.0"
+        "pretty-format": "23.5.0"
       }
     },
     "jest-matcher-utils": {
@@ -8139,9 +8140,9 @@
       "integrity": "sha512-hmQUKUKYOExp3T8dNYK9A9copCFYKoRLcY4WDJJ0Z2u3oF6rmAhHuZtmpHBuGpASazobBxm3TXAfAXDvz2T7+Q==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "pretty-format": "^23.5.0"
+        "chalk": "2.4.1",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.5.0"
       }
     },
     "jest-message-util": {
@@ -8150,11 +8151,11 @@
       "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0-beta.35",
-        "chalk": "^2.0.1",
-        "micromatch": "^2.3.11",
-        "slash": "^1.0.0",
-        "stack-utils": "^1.0.1"
+        "@babel/code-frame": "7.0.0",
+        "chalk": "2.4.1",
+        "micromatch": "2.3.11",
+        "slash": "1.0.0",
+        "stack-utils": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -8163,7 +8164,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -8178,9 +8179,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "expand-brackets": {
@@ -8189,7 +8190,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -8198,7 +8199,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -8213,7 +8214,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -8222,7 +8223,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -8231,19 +8232,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "slash": {
@@ -8272,9 +8273,9 @@
       "integrity": "sha512-CRPc0ebG3baNKz/QicIy5rGfzYpMNm8AjEl/tDQhehq/QC4ttyauZdvAXel3qo+4Gri9ljajnxW+hWyxZbbcnQ==",
       "dev": true,
       "requires": {
-        "browser-resolve": "^1.11.3",
-        "chalk": "^2.0.1",
-        "realpath-native": "^1.0.0"
+        "browser-resolve": "1.11.3",
+        "chalk": "2.4.1",
+        "realpath-native": "1.0.1"
       }
     },
     "jest-resolve-dependencies": {
@@ -8283,8 +8284,8 @@
       "integrity": "sha512-APZc/CjfzL8rH/wr+Gh7XJJygYaDjMQsWaJy4ZR1WaHWKude4WcfdU8xjqaNbx5NsVF2P2tVvsLbumlPXCdJOw==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "^23.3.0",
-        "jest-snapshot": "^23.5.0"
+        "jest-regex-util": "23.3.0",
+        "jest-snapshot": "23.5.0"
       }
     },
     "jest-runner": {
@@ -8293,19 +8294,19 @@
       "integrity": "sha512-cpBvkBTVmW1ab1thbtoh2m6VnnM0BYKhj3MEzbOTZjPfzoIjUVIxLUTDobVNOvEK7aTEb/2oiPlNoOTSNJx8mw==",
       "dev": true,
       "requires": {
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^23.5.0",
-        "jest-docblock": "^23.2.0",
-        "jest-haste-map": "^23.5.0",
-        "jest-jasmine2": "^23.5.0",
-        "jest-leak-detector": "^23.5.0",
-        "jest-message-util": "^23.4.0",
-        "jest-runtime": "^23.5.0",
-        "jest-util": "^23.4.0",
-        "jest-worker": "^23.2.0",
-        "source-map-support": "^0.5.6",
-        "throat": "^4.0.0"
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.11",
+        "jest-config": "23.5.0",
+        "jest-docblock": "23.2.0",
+        "jest-haste-map": "23.5.0",
+        "jest-jasmine2": "23.5.0",
+        "jest-leak-detector": "23.5.0",
+        "jest-message-util": "23.4.0",
+        "jest-runtime": "23.5.0",
+        "jest-util": "23.4.0",
+        "jest-worker": "23.2.0",
+        "source-map-support": "0.5.9",
+        "throat": "4.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -8320,8 +8321,8 @@
           "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
+            "buffer-from": "1.1.1",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -8332,27 +8333,27 @@
       "integrity": "sha512-WzzYxYtoU8S1MJns0G4E3BsuFUTFBiu1qsk3iC9OTugzNQcQKt0BoOGsT7wXCKqkw/09QdV77vvaeJXST2Efgg==",
       "dev": true,
       "requires": {
-        "babel-core": "^6.0.0",
-        "babel-plugin-istanbul": "^4.1.6",
-        "chalk": "^2.0.1",
-        "convert-source-map": "^1.4.0",
-        "exit": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "jest-config": "^23.5.0",
-        "jest-haste-map": "^23.5.0",
-        "jest-message-util": "^23.4.0",
-        "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.5.0",
-        "jest-snapshot": "^23.5.0",
-        "jest-util": "^23.4.0",
-        "jest-validate": "^23.5.0",
-        "micromatch": "^2.3.11",
-        "realpath-native": "^1.0.0",
-        "slash": "^1.0.0",
+        "babel-core": "6.26.3",
+        "babel-plugin-istanbul": "4.1.6",
+        "chalk": "2.4.1",
+        "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
+        "fast-json-stable-stringify": "2.0.0",
+        "graceful-fs": "4.1.11",
+        "jest-config": "23.5.0",
+        "jest-haste-map": "23.5.0",
+        "jest-message-util": "23.4.0",
+        "jest-regex-util": "23.3.0",
+        "jest-resolve": "23.5.0",
+        "jest-snapshot": "23.5.0",
+        "jest-util": "23.4.0",
+        "jest-validate": "23.5.0",
+        "micromatch": "2.3.11",
+        "realpath-native": "1.0.1",
+        "slash": "1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "^2.1.0",
-        "yargs": "^11.0.0"
+        "write-file-atomic": "2.3.0",
+        "yargs": "11.1.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -8361,7 +8362,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -8376,25 +8377,25 @@
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.1",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           }
         },
         "babylon": {
@@ -8409,9 +8410,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "expand-brackets": {
@@ -8420,7 +8421,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -8429,7 +8430,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -8444,7 +8445,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -8453,7 +8454,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -8462,19 +8463,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "slash": {
@@ -8489,9 +8490,9 @@
           "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
           }
         }
       }
@@ -8508,16 +8509,16 @@
       "integrity": "sha512-NYg8MFNVyPXmnnihiltasr4t1FJEXFbZFaw1vZCowcnezIQ9P1w+yxTwjWT564QP24Zbn5L9cjxLs8d6K+pNlw==",
       "dev": true,
       "requires": {
-        "babel-types": "^6.0.0",
-        "chalk": "^2.0.1",
-        "jest-diff": "^23.5.0",
-        "jest-matcher-utils": "^23.5.0",
-        "jest-message-util": "^23.4.0",
-        "jest-resolve": "^23.5.0",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^23.5.0",
-        "semver": "^5.5.0"
+        "babel-types": "6.26.0",
+        "chalk": "2.4.1",
+        "jest-diff": "23.5.0",
+        "jest-matcher-utils": "23.5.0",
+        "jest-message-util": "23.4.0",
+        "jest-resolve": "23.5.0",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "pretty-format": "23.5.0",
+        "semver": "5.5.1"
       }
     },
     "jest-util": {
@@ -8526,14 +8527,14 @@
       "integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
       "dev": true,
       "requires": {
-        "callsites": "^2.0.0",
-        "chalk": "^2.0.1",
-        "graceful-fs": "^4.1.11",
-        "is-ci": "^1.0.10",
-        "jest-message-util": "^23.4.0",
-        "mkdirp": "^0.5.1",
-        "slash": "^1.0.0",
-        "source-map": "^0.6.0"
+        "callsites": "2.0.0",
+        "chalk": "2.4.1",
+        "graceful-fs": "4.1.11",
+        "is-ci": "1.2.0",
+        "jest-message-util": "23.4.0",
+        "mkdirp": "0.5.1",
+        "slash": "1.0.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "slash": {
@@ -8556,10 +8557,10 @@
       "integrity": "sha512-XmStdYhfdiDKacXX5sNqEE61Zz4/yXaPcDsKvVA0429RBu2pkQyIltCVG7UitJIEAzSs3ociQTdyseAW8VGPiA==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.1.0",
-        "leven": "^2.1.0",
-        "pretty-format": "^23.5.0"
+        "chalk": "2.4.1",
+        "jest-get-type": "22.4.3",
+        "leven": "2.1.0",
+        "pretty-format": "23.5.0"
       }
     },
     "jest-watcher": {
@@ -8568,9 +8569,9 @@
       "integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
-        "string-length": "^2.0.0"
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.4.1",
+        "string-length": "2.0.0"
       }
     },
     "jest-worker": {
@@ -8579,7 +8580,7 @@
       "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
       "dev": true,
       "requires": {
-        "merge-stream": "^1.0.1"
+        "merge-stream": "1.0.1"
       }
     },
     "js-base64": {
@@ -8606,8 +8607,8 @@
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       }
     },
     "jsbn": {
@@ -8623,21 +8624,21 @@
       "integrity": "sha512-sRMollbhbmSDrR79JMAnhEjyZJlQQVozeeY9A6/KNuV26DNcuB3mGSCWXp0hks9dcwRNOELbNOiwraZaXXRk5Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "^6.8.0",
-        "babel-preset-es2015": "^6.9.0",
-        "babel-preset-stage-1": "^6.5.0",
-        "babel-register": "^6.9.0",
-        "babylon": "^7.0.0-beta.47",
-        "colors": "^1.1.2",
-        "flow-parser": "^0.*",
-        "lodash": "^4.13.1",
-        "micromatch": "^2.3.7",
-        "neo-async": "^2.5.0",
+        "babel-plugin-transform-flow-strip-types": "6.22.0",
+        "babel-preset-es2015": "6.24.1",
+        "babel-preset-stage-1": "6.24.1",
+        "babel-register": "6.26.0",
+        "babylon": "7.0.0-beta.47",
+        "colors": "1.1.2",
+        "flow-parser": "0.79.1",
+        "lodash": "4.17.10",
+        "micromatch": "2.3.11",
+        "neo-async": "2.5.2",
         "node-dir": "0.1.8",
-        "nomnom": "^1.8.1",
-        "recast": "^0.15.0",
-        "temp": "^0.8.1",
-        "write-file-atomic": "^1.2.0"
+        "nomnom": "1.8.1",
+        "recast": "0.15.3",
+        "temp": "0.8.3",
+        "write-file-atomic": "1.3.4"
       },
       "dependencies": {
         "arr-diff": {
@@ -8646,7 +8647,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -8661,9 +8662,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "expand-brackets": {
@@ -8672,7 +8673,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -8681,7 +8682,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -8696,7 +8697,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -8705,7 +8706,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -8714,19 +8715,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         }
       }
@@ -8737,32 +8738,32 @@
       "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.0",
-        "acorn": "^5.5.3",
-        "acorn-globals": "^4.1.0",
-        "array-equal": "^1.0.0",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": "^1.0.0",
-        "data-urls": "^1.0.0",
-        "domexception": "^1.0.1",
-        "escodegen": "^1.9.1",
-        "html-encoding-sniffer": "^1.0.2",
-        "left-pad": "^1.3.0",
-        "nwsapi": "^2.0.7",
+        "abab": "2.0.0",
+        "acorn": "5.7.2",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "cssom": "0.3.4",
+        "cssstyle": "1.1.1",
+        "data-urls": "1.0.1",
+        "domexception": "1.0.1",
+        "escodegen": "1.11.0",
+        "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.3.0",
+        "nwsapi": "2.0.8",
         "parse5": "4.0.0",
-        "pn": "^1.1.0",
-        "request": "^2.87.0",
-        "request-promise-native": "^1.0.5",
-        "sax": "^1.2.4",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^2.3.4",
-        "w3c-hr-time": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.3",
-        "whatwg-mimetype": "^2.1.0",
-        "whatwg-url": "^6.4.1",
-        "ws": "^5.2.0",
-        "xml-name-validator": "^3.0.0"
+        "pn": "1.1.0",
+        "request": "2.88.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.4.3",
+        "w3c-hr-time": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.5.0",
+        "ws": "5.2.2",
+        "xml-name-validator": "3.0.0"
       }
     },
     "jsesc": {
@@ -8865,7 +8866,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "left-pad": {
@@ -8886,8 +8887,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lint-staged": {
@@ -8896,28 +8897,28 @@
       "integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.1",
-        "commander": "^2.14.1",
-        "cosmiconfig": "^5.0.2",
-        "debug": "^3.1.0",
-        "dedent": "^0.7.0",
-        "execa": "^0.9.0",
-        "find-parent-dir": "^0.3.0",
-        "is-glob": "^4.0.0",
-        "is-windows": "^1.0.2",
-        "jest-validate": "^23.5.0",
-        "listr": "^0.14.1",
-        "lodash": "^4.17.5",
-        "log-symbols": "^2.2.0",
-        "micromatch": "^3.1.8",
-        "npm-which": "^3.0.1",
-        "p-map": "^1.1.1",
-        "path-is-inside": "^1.0.2",
-        "pify": "^3.0.0",
-        "please-upgrade-node": "^3.0.2",
+        "chalk": "2.4.1",
+        "commander": "2.15.1",
+        "cosmiconfig": "5.0.6",
+        "debug": "3.2.6",
+        "dedent": "0.7.0",
+        "execa": "0.9.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "is-windows": "1.0.2",
+        "jest-validate": "23.5.0",
+        "listr": "0.14.1",
+        "lodash": "4.17.10",
+        "log-symbols": "2.2.0",
+        "micromatch": "3.1.10",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "please-upgrade-node": "3.1.1",
         "staged-git-files": "1.1.1",
-        "string-argv": "^0.0.2",
-        "stringify-object": "^3.2.2"
+        "string-argv": "0.0.2",
+        "stringify-object": "3.2.2"
       },
       "dependencies": {
         "cross-spawn": {
@@ -8926,9 +8927,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "debug": {
@@ -8937,7 +8938,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "execa": {
@@ -8946,13 +8947,13 @@
           "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "ms": {
@@ -8969,22 +8970,22 @@
       "integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
       "dev": true,
       "requires": {
-        "@samverschueren/stream-to-observable": "^0.3.0",
-        "cli-truncate": "^0.2.1",
-        "figures": "^1.7.0",
-        "indent-string": "^2.1.0",
-        "is-observable": "^1.1.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.4.0",
-        "listr-verbose-renderer": "^0.4.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^1.0.2",
-        "ora": "^0.2.3",
-        "p-map": "^1.1.1",
-        "rxjs": "^6.1.0",
-        "strip-ansi": "^3.0.1"
+        "@samverschueren/stream-to-observable": "0.3.0",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "1.1.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "6.2.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9005,11 +9006,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "figures": {
@@ -9018,8 +9019,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "log-symbols": {
@@ -9028,7 +9029,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         },
         "rxjs": {
@@ -9037,7 +9038,7 @@
           "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
           "dev": true,
           "requires": {
-            "tslib": "^1.9.0"
+            "tslib": "1.9.3"
           }
         },
         "strip-ansi": {
@@ -9046,7 +9047,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -9069,14 +9070,14 @@
       "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^1.0.2",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9097,11 +9098,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "figures": {
@@ -9110,8 +9111,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "indent-string": {
@@ -9126,7 +9127,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         },
         "strip-ansi": {
@@ -9135,7 +9136,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -9152,10 +9153,10 @@
       "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-cursor": "^1.0.2",
-        "date-fns": "^1.27.2",
-        "figures": "^1.7.0"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9176,11 +9177,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cli-cursor": {
@@ -9189,7 +9190,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "figures": {
@@ -9198,8 +9199,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "onetime": {
@@ -9214,8 +9215,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "strip-ansi": {
@@ -9224,7 +9225,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -9241,10 +9242,10 @@
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       }
     },
     "loader-runner": {
@@ -9259,9 +9260,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
       }
     },
     "locate-path": {
@@ -9270,8 +9271,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -9316,7 +9317,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.1"
       }
     },
     "log-update": {
@@ -9325,8 +9326,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.0.0",
-        "cli-cursor": "^1.0.2"
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -9341,7 +9342,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "onetime": {
@@ -9356,8 +9357,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         }
       }
@@ -9386,7 +9387,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -9395,8 +9396,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lower-case": {
@@ -9417,8 +9418,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-dir": {
@@ -9427,7 +9428,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "makeerror": {
@@ -9436,7 +9437,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "mamacro": {
@@ -9463,7 +9464,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "math-expression-evaluator": {
@@ -9484,8 +9485,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "media-typer": {
@@ -9500,7 +9501,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "mem-fs": {
@@ -9509,9 +9510,9 @@
       "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.0",
-        "vinyl": "^1.1.0",
-        "vinyl-file": "^2.0.0"
+        "through2": "2.0.3",
+        "vinyl": "1.2.0",
+        "vinyl-file": "2.0.0"
       }
     },
     "mem-fs-editor": {
@@ -9520,17 +9521,17 @@
       "integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "deep-extend": "^0.6.0",
-        "ejs": "^2.5.9",
-        "glob": "^7.0.3",
-        "globby": "^7.1.1",
-        "isbinaryfile": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "multimatch": "^2.0.0",
-        "rimraf": "^2.2.8",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.1"
+        "commondir": "1.0.1",
+        "deep-extend": "0.6.0",
+        "ejs": "2.6.1",
+        "glob": "7.1.3",
+        "globby": "7.1.1",
+        "isbinaryfile": "3.0.3",
+        "mkdirp": "0.5.1",
+        "multimatch": "2.1.0",
+        "rimraf": "2.6.2",
+        "through2": "2.0.3",
+        "vinyl": "2.2.0"
       },
       "dependencies": {
         "clone": {
@@ -9551,12 +9552,12 @@
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "glob": "7.1.3",
+            "ignore": "3.3.10",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
           }
         },
         "replace-ext": {
@@ -9577,12 +9578,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -9593,8 +9594,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.6"
       }
     },
     "meow": {
@@ -9603,16 +9604,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -9621,8 +9622,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "load-json-file": {
@@ -9631,11 +9632,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "minimist": {
@@ -9650,7 +9651,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         },
         "path-exists": {
@@ -9659,7 +9660,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -9668,9 +9669,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -9685,9 +9686,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -9696,8 +9697,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "strip-bom": {
@@ -9706,7 +9707,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -9729,7 +9730,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "merge2": {
@@ -9750,19 +9751,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "miller-rabin": {
@@ -9771,8 +9772,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mime": {
@@ -9793,7 +9794,7 @@
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "1.36.0"
       }
     },
     "mimic-fn": {
@@ -9826,7 +9827,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -9841,16 +9842,16 @@
       "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^2.0.1",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
+        "concat-stream": "1.6.2",
+        "duplexify": "3.6.0",
+        "end-of-stream": "1.4.1",
+        "flush-write-stream": "1.0.3",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "2.0.1",
+        "pumpify": "1.5.1",
+        "stream-each": "1.2.3",
+        "through2": "2.0.3"
       }
     },
     "mixin-deep": {
@@ -9859,8 +9860,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -9869,7 +9870,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -9889,12 +9890,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
       }
     },
     "ms": {
@@ -9909,8 +9910,8 @@
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
-        "dns-packet": "^1.3.1",
-        "thunky": "^1.0.2"
+        "dns-packet": "1.3.1",
+        "thunky": "1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -9925,10 +9926,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "mute-stream": {
@@ -9950,17 +9951,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "natural-compare": {
@@ -9993,7 +9994,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "^1.1.1"
+        "lower-case": "1.1.4"
       }
     },
     "node-dir": {
@@ -10008,8 +10009,8 @@
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
       }
     },
     "node-forge": {
@@ -10030,28 +10031,28 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^1.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.4.1",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "1.1.1",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.0",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.6",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.8.3",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.10.3",
+        "url": "0.11.0",
+        "util": "0.10.4",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -10069,10 +10070,10 @@
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
-        "growly": "^1.3.0",
-        "semver": "^5.4.1",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
+        "growly": "1.3.0",
+        "semver": "5.5.1",
+        "shellwords": "0.1.1",
+        "which": "1.3.1"
       }
     },
     "node-releases": {
@@ -10081,7 +10082,7 @@
       "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.1"
       }
     },
     "nomnom": {
@@ -10090,8 +10091,8 @@
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
+        "chalk": "0.4.0",
+        "underscore": "1.6.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10106,9 +10107,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
           }
         },
         "strip-ansi": {
@@ -10125,10 +10126,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.1",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -10137,7 +10138,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -10152,10 +10153,10 @@
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "prepend-http": "^1.0.0",
-        "query-string": "^4.1.0",
-        "sort-keys": "^1.0.0"
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
       }
     },
     "npm-path": {
@@ -10164,7 +10165,7 @@
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
-        "which": "^1.2.10"
+        "which": "1.3.1"
       }
     },
     "npm-run-path": {
@@ -10173,7 +10174,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npm-which": {
@@ -10182,9 +10183,9 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "^2.9.0",
-        "npm-path": "^2.0.2",
-        "which": "^1.2.10"
+        "commander": "2.15.1",
+        "npm-path": "2.0.4",
+        "which": "1.3.1"
       }
     },
     "nth-check": {
@@ -10193,7 +10194,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "num2fraction": {
@@ -10232,9 +10233,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -10243,7 +10244,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -10252,7 +10253,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -10269,7 +10270,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -10278,8 +10279,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0"
       }
     },
     "object.omit": {
@@ -10288,8 +10289,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -10298,7 +10299,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "obuf": {
@@ -10328,7 +10329,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -10337,7 +10338,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "opn": {
@@ -10346,7 +10347,7 @@
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -10355,8 +10356,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
       }
     },
     "optionator": {
@@ -10365,12 +10366,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -10387,10 +10388,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "cli-cursor": "^1.0.2",
-        "cli-spinners": "^0.1.2",
-        "object-assign": "^4.0.1"
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10411,11 +10412,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cli-cursor": {
@@ -10424,7 +10425,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "onetime": {
@@ -10439,8 +10440,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "strip-ansi": {
@@ -10449,7 +10450,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -10466,7 +10467,7 @@
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "dev": true,
       "requires": {
-        "url-parse": "^1.4.3"
+        "url-parse": "1.4.3"
       }
     },
     "os-browserify": {
@@ -10487,9 +10488,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
       }
     },
     "os-tmpdir": {
@@ -10504,9 +10505,9 @@
       "integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "is-plain-obj": "^1.1.0",
-        "mkdirp": "^0.5.1"
+        "graceful-fs": "4.1.11",
+        "is-plain-obj": "1.1.0",
+        "mkdirp": "0.5.1"
       }
     },
     "p-cancelable": {
@@ -10521,7 +10522,7 @@
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "p-finally": {
@@ -10548,7 +10549,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -10557,7 +10558,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-map": {
@@ -10578,7 +10579,7 @@
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -10599,9 +10600,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "~0.2.2",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "param-case": {
@@ -10610,7 +10611,7 @@
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
-        "no-case": "^2.2.0"
+        "no-case": "2.3.2"
       }
     },
     "parse-asn1": {
@@ -10619,11 +10620,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.16"
       }
     },
     "parse-glob": {
@@ -10632,10 +10633,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -10650,7 +10651,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -10661,8 +10662,8 @@
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.2",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "parse-passwd": {
@@ -10743,7 +10744,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "pbkdf2": {
@@ -10752,11 +10753,11 @@
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "performance-now": {
@@ -10783,7 +10784,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -10792,7 +10793,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       }
     },
     "please-upgrade-node": {
@@ -10801,7 +10802,7 @@
       "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
       "dev": true,
       "requires": {
-        "semver-compare": "^1.0.0"
+        "semver-compare": "1.0.0"
       }
     },
     "pn": {
@@ -10816,9 +10817,9 @@
       "integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
       "dev": true,
       "requires": {
-        "async": "^1.5.2",
-        "debug": "^2.2.0",
-        "mkdirp": "0.5.x"
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
       }
     },
     "posix-character-classes": {
@@ -10833,10 +10834,10 @@
       "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "js-base64": "^2.1.9",
-        "source-map": "^0.5.6",
-        "supports-color": "^3.2.3"
+        "chalk": "1.1.3",
+        "js-base64": "2.4.5",
+        "source-map": "0.5.7",
+        "supports-color": "3.2.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10857,11 +10858,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -10878,7 +10879,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "has-flag": {
@@ -10893,7 +10894,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -10902,7 +10903,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -10913,9 +10914,9 @@
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.2",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-css-calc": "^1.2.6"
+        "postcss": "5.2.18",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
       }
     },
     "postcss-colormin": {
@@ -10924,9 +10925,9 @@
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "dev": true,
       "requires": {
-        "colormin": "^1.0.5",
-        "postcss": "^5.0.13",
-        "postcss-value-parser": "^3.2.3"
+        "colormin": "1.1.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-convert-values": {
@@ -10935,8 +10936,8 @@
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.11",
-        "postcss-value-parser": "^3.1.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-discard-comments": {
@@ -10945,7 +10946,7 @@
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-duplicates": {
@@ -10954,7 +10955,7 @@
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-empty": {
@@ -10963,7 +10964,7 @@
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.14"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-overridden": {
@@ -10972,7 +10973,7 @@
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.16"
+        "postcss": "5.2.18"
       }
     },
     "postcss-discard-unused": {
@@ -10981,8 +10982,8 @@
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.14",
-        "uniqs": "^2.0.0"
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-filter-plugins": {
@@ -10991,7 +10992,7 @@
       "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-merge-idents": {
@@ -11000,9 +11001,9 @@
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.10",
-        "postcss-value-parser": "^3.1.1"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-merge-longhand": {
@@ -11011,7 +11012,7 @@
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-merge-rules": {
@@ -11020,11 +11021,11 @@
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
       "requires": {
-        "browserslist": "^1.5.2",
-        "caniuse-api": "^1.5.2",
-        "postcss": "^5.0.4",
-        "postcss-selector-parser": "^2.2.2",
-        "vendors": "^1.0.0"
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.2"
       },
       "dependencies": {
         "browserslist": {
@@ -11033,8 +11034,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000846",
+            "electron-to-chromium": "1.3.48"
           }
         }
       }
@@ -11051,9 +11052,9 @@
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "object-assign": "4.1.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-minify-gradients": {
@@ -11062,8 +11063,8 @@
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.12",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-minify-params": {
@@ -11072,10 +11073,10 @@
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.2",
-        "postcss-value-parser": "^3.0.2",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-minify-selectors": {
@@ -11084,10 +11085,10 @@
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.2",
-        "has": "^1.0.1",
-        "postcss": "^5.0.14",
-        "postcss-selector-parser": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-modules-extract-imports": {
@@ -11096,7 +11097,7 @@
       "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "postcss": {
@@ -11105,9 +11106,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11124,8 +11125,8 @@
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "postcss": {
@@ -11134,9 +11135,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11153,8 +11154,8 @@
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "postcss": {
@@ -11163,9 +11164,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11182,8 +11183,8 @@
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
       "requires": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.22"
       },
       "dependencies": {
         "postcss": {
@@ -11192,9 +11193,9 @@
           "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.4.0"
           }
         },
         "source-map": {
@@ -11211,7 +11212,7 @@
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.5"
+        "postcss": "5.2.18"
       }
     },
     "postcss-normalize-url": {
@@ -11220,10 +11221,10 @@
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^1.4.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3"
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-ordered-values": {
@@ -11232,8 +11233,8 @@
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.1"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-reduce-idents": {
@@ -11242,8 +11243,8 @@
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-reduce-initial": {
@@ -11252,7 +11253,7 @@
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       }
     },
     "postcss-reduce-transforms": {
@@ -11261,9 +11262,9 @@
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.8",
-        "postcss-value-parser": "^3.0.1"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-selector-parser": {
@@ -11272,9 +11273,9 @@
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-svgo": {
@@ -11283,10 +11284,10 @@
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
-        "is-svg": "^2.0.0",
-        "postcss": "^5.0.14",
-        "postcss-value-parser": "^3.2.3",
-        "svgo": "^0.7.0"
+        "is-svg": "2.1.0",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
       }
     },
     "postcss-unique-selectors": {
@@ -11295,9 +11296,9 @@
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "postcss-value-parser": {
@@ -11312,9 +11313,9 @@
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "has": "1.0.1",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       }
     },
     "prelude-ls": {
@@ -11353,8 +11354,8 @@
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "dev": true,
       "requires": {
-        "renderkid": "^2.0.1",
-        "utila": "~0.4"
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
       }
     },
     "pretty-format": {
@@ -11363,8 +11364,8 @@
       "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
       }
     },
     "private": {
@@ -11391,7 +11392,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "~2.0.3"
+        "asap": "2.0.6"
       }
     },
     "promise-inflight": {
@@ -11406,8 +11407,8 @@
       "integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
       "dev": true,
       "requires": {
-        "kleur": "^2.0.1",
-        "sisteransi": "^0.1.1"
+        "kleur": "2.0.1",
+        "sisteransi": "0.1.1"
       }
     },
     "prop-types": {
@@ -11416,8 +11417,8 @@
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
       }
     },
     "proxy-addr": {
@@ -11426,7 +11427,7 @@
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -11454,11 +11455,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.1",
+        "randombytes": "2.0.6"
       }
     },
     "pump": {
@@ -11467,8 +11468,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -11477,9 +11478,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.6.0",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -11506,8 +11507,8 @@
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "querystring": {
@@ -11534,7 +11535,7 @@
       "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
       "dev": true,
       "requires": {
-        "performance-now": "^2.1.0"
+        "performance-now": "2.1.0"
       }
     },
     "randomatic": {
@@ -11543,9 +11544,9 @@
       "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -11562,7 +11563,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
@@ -11571,8 +11572,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.0.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "range-parser": {
@@ -11608,7 +11609,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "statuses": "1.4.0"
           }
         },
         "iconv-lite": {
@@ -11631,10 +11632,10 @@
       "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-dom": {
@@ -11643,10 +11644,10 @@
       "integrity": "sha512-Usl73nQqzvmJN+89r97zmeUpQDKDlh58eX6Hbs/ERdDHzeBzWy+ENk7fsGQ+5KxArV1iOFPT46/VneklK9zoWw==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
+        "fbjs": "0.8.17",
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2"
       }
     },
     "react-is": {
@@ -11661,10 +11662,10 @@
       "integrity": "sha512-AGbJYbCVx1J6jdUgI4s0hNp+9LxlgzKvXl0ROA3DHTrtjAr00Po1RhDZ/eAq2VC/ww8AHgpDXULh5V2rhEqqJg==",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.5.2",
-        "schedule": "^0.5.0"
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.2",
+        "react-is": "16.5.2",
+        "schedule": "0.5.0"
       }
     },
     "read-chunk": {
@@ -11673,8 +11674,8 @@
       "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1"
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "read-pkg": {
@@ -11683,9 +11684,9 @@
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
@@ -11694,8 +11695,8 @@
       "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "3.0.0"
       }
     },
     "readable-stream": {
@@ -11704,13 +11705,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -11719,10 +11720,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "realpath-native": {
@@ -11731,7 +11732,7 @@
       "integrity": "sha512-W14EcXuqUvKP8dkWkD7B95iMy77lpMnlFXbbk409bQtNCbeu0kvRE5reo+yIZ3JXxg6frbGsz2DLQ39lrCB40g==",
       "dev": true,
       "requires": {
-        "util.promisify": "^1.0.0"
+        "util.promisify": "1.0.0"
       }
     },
     "recast": {
@@ -11741,9 +11742,9 @@
       "dev": true,
       "requires": {
         "ast-types": "0.11.5",
-        "esprima": "~4.0.0",
-        "private": "~0.1.5",
-        "source-map": "~0.6.1"
+        "esprima": "4.0.1",
+        "private": "0.1.8",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -11766,7 +11767,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.8.1"
       }
     },
     "redent": {
@@ -11775,8 +11776,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -11785,9 +11786,9 @@
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.2",
-        "math-expression-evaluator": "^1.2.14",
-        "reduce-function-call": "^1.0.1"
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -11804,7 +11805,7 @@
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.2"
+        "balanced-match": "0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -11827,7 +11828,7 @@
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -11842,7 +11843,7 @@
       "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
       "dev": true,
       "requires": {
-        "private": "^0.1.6"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -11851,7 +11852,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -11860,8 +11861,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpu-core": {
@@ -11870,12 +11871,12 @@
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^7.0.0",
-        "regjsgen": "^0.4.0",
-        "regjsparser": "^0.3.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.0.2"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "7.0.0",
+        "regjsgen": "0.4.0",
+        "regjsparser": "0.3.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.0.2"
       }
     },
     "regjsgen": {
@@ -11890,7 +11891,7 @@
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -11919,11 +11920,11 @@
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
       "requires": {
-        "css-select": "^1.1.0",
-        "dom-converter": "~0.1",
-        "htmlparser2": "~3.3.0",
-        "strip-ansi": "^3.0.0",
-        "utila": "~0.3"
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11938,7 +11939,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "utila": {
@@ -11967,7 +11968,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -11982,26 +11983,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "qs": {
@@ -12018,7 +12019,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.10"
       }
     },
     "request-promise-native": {
@@ -12028,8 +12029,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.4.3"
       }
     },
     "require-directory": {
@@ -12056,7 +12057,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-cwd": {
@@ -12065,7 +12066,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -12074,8 +12075,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -12096,7 +12097,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -12105,8 +12106,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -12122,7 +12123,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "rimraf": {
@@ -12131,7 +12132,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.3"
       }
     },
     "ripemd160": {
@@ -12140,8 +12141,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "rsvp": {
@@ -12156,7 +12157,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-node": {
@@ -12171,7 +12172,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1"
+        "aproba": "1.2.0"
       }
     },
     "rx": {
@@ -12201,7 +12202,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -12216,15 +12217,15 @@
       "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "capture-exit": "^1.2.0",
-        "exec-sh": "^0.2.0",
-        "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.3",
-        "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.18.0"
+        "anymatch": "2.0.0",
+        "capture-exit": "1.2.0",
+        "exec-sh": "0.2.2",
+        "fb-watchman": "2.0.0",
+        "fsevents": "1.2.4",
+        "micromatch": "3.1.10",
+        "minimist": "1.2.0",
+        "walker": "1.0.7",
+        "watch": "0.18.0"
       },
       "dependencies": {
         "minimist": {
@@ -12247,7 +12248,7 @@
       "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.1"
+        "object-assign": "4.1.1"
       }
     },
     "schema-utils": {
@@ -12256,8 +12257,8 @@
       "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0"
+        "ajv": "6.5.0",
+        "ajv-keywords": "3.2.0"
       }
     },
     "scoped-regex": {
@@ -12300,18 +12301,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       }
     },
     "serialize-javascript": {
@@ -12326,13 +12327,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.20",
+        "parseurl": "1.3.2"
       }
     },
     "serve-static": {
@@ -12341,9 +12342,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -12365,10 +12366,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -12377,7 +12378,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -12400,8 +12401,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "shebang-command": {
@@ -12410,7 +12411,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -12425,9 +12426,9 @@
       "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.3",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       }
     },
     "shellwords": {
@@ -12472,14 +12473,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -12488,7 +12489,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -12497,7 +12498,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -12508,9 +12509,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -12519,7 +12520,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -12528,7 +12529,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -12537,7 +12538,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -12546,9 +12547,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -12559,7 +12560,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -12568,7 +12569,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -12579,8 +12580,8 @@
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "dev": true,
       "requires": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "0.10.0",
+        "uuid": "3.3.2"
       }
     },
     "sockjs-client": {
@@ -12589,12 +12590,12 @@
       "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.6",
+        "debug": "2.6.9",
         "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.4.3"
       },
       "dependencies": {
         "faye-websocket": {
@@ -12603,7 +12604,7 @@
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
           "dev": true,
           "requires": {
-            "websocket-driver": ">=0.5.1"
+            "websocket-driver": "0.7.0"
           }
         }
       }
@@ -12614,7 +12615,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-list-map": {
@@ -12635,11 +12636,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -12648,7 +12649,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "source-map-url": {
@@ -12669,8 +12670,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -12685,8 +12686,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -12701,12 +12702,12 @@
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "handle-thing": "^1.2.5",
-        "http-deceiver": "^1.2.7",
-        "safe-buffer": "^5.0.1",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^2.0.18"
+        "debug": "2.6.9",
+        "handle-thing": "1.2.5",
+        "http-deceiver": "1.2.7",
+        "safe-buffer": "5.1.2",
+        "select-hose": "2.0.0",
+        "spdy-transport": "2.1.0"
       }
     },
     "spdy-transport": {
@@ -12715,13 +12716,13 @@
       "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "detect-node": "^2.0.3",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.1",
-        "readable-stream": "^2.2.9",
-        "safe-buffer": "^5.0.1",
-        "wbuf": "^1.7.2"
+        "debug": "2.6.9",
+        "detect-node": "2.0.3",
+        "hpack.js": "2.1.6",
+        "obuf": "1.1.2",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "wbuf": "1.7.3"
       }
     },
     "split-string": {
@@ -12730,7 +12731,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -12745,15 +12746,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "ssri": {
@@ -12762,7 +12763,7 @@
       "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "stack-utils": {
@@ -12783,8 +12784,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -12793,7 +12794,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -12816,8 +12817,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "stream-each": {
@@ -12826,8 +12827,8 @@
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "stream-shift": "1.0.0"
       }
     },
     "stream-http": {
@@ -12836,11 +12837,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
       }
     },
     "stream-shift": {
@@ -12867,8 +12868,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "^1.0.0",
-        "strip-ansi": "^4.0.0"
+        "astral-regex": "1.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string-template": {
@@ -12883,8 +12884,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string_decoder": {
@@ -12893,7 +12894,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringify-object": {
@@ -12902,9 +12903,9 @@
       "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "^2.0.1",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "strip-ansi": {
@@ -12913,7 +12914,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-bom": {
@@ -12928,8 +12929,8 @@
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "2.0.0",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -12938,7 +12939,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -12955,7 +12956,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "style-loader": {
@@ -12964,8 +12965,8 @@
       "integrity": "sha512-T+UNsAcl3Yg+BsPKs1vd22Fr8sVT+CJMtzqc6LEw9bbJZb43lm9GoeIfUcDEefBSWC0BhYbcdupV1GtI4DGzxg==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^0.4.5"
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.4.5"
       }
     },
     "supports-color": {
@@ -12974,7 +12975,7 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "svgo": {
@@ -12983,13 +12984,13 @@
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
       "requires": {
-        "coa": "~1.0.1",
-        "colors": "~1.1.2",
-        "csso": "~2.3.1",
-        "js-yaml": "~3.7.0",
-        "mkdirp": "~0.5.1",
-        "sax": "~1.2.1",
-        "whet.extend": "~0.9.9"
+        "coa": "1.0.4",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.4",
+        "whet.extend": "0.9.9"
       }
     },
     "symbol-observable": {
@@ -13016,8 +13017,8 @@
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "^1.0.0",
-        "rimraf": "~2.2.6"
+        "os-tmpdir": "1.0.2",
+        "rimraf": "2.2.8"
       },
       "dependencies": {
         "rimraf": {
@@ -13034,10 +13035,10 @@
       "integrity": "sha512-2kTGf+3tykCfrWVREgyTR0bmVO0afE6i7zVXi/m+bZZ8ujV89Aulxdcdv32yH+unVFg3Y5o6GA8IzsHnGQuFgQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^3.0.0",
-        "require-main-filename": "^1.0.1"
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "3.0.0",
+        "require-main-filename": "1.0.1"
       }
     },
     "text-table": {
@@ -13070,8 +13071,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "thunky": {
@@ -13092,7 +13093,7 @@
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "tmp": {
@@ -13101,7 +13102,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "tmpl": {
@@ -13128,7 +13129,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -13137,7 +13138,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -13148,10 +13149,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -13160,8 +13161,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "toposort": {
@@ -13176,8 +13177,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.29",
+        "punycode": "1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -13194,7 +13195,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "tree-kill": {
@@ -13233,7 +13234,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -13249,7 +13250,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -13259,7 +13260,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.20"
       }
     },
     "typedarray": {
@@ -13280,8 +13281,8 @@
       "integrity": "sha512-O94wxMSb3td/TlofkITYvYIlvIVdldvNXDVRekzK13CQZuL37ua4nrdXX0Ro7MapfUVzglRHs0/+imPRUdOghg==",
       "dev": true,
       "requires": {
-        "commander": "~2.15.0",
-        "source-map": "~0.6.1"
+        "commander": "2.15.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -13305,14 +13306,14 @@
       "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
       "dev": true,
       "requires": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "schema-utils": "^0.4.5",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-es": "^3.3.4",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
+        "cacache": "10.0.4",
+        "find-cache-dir": "1.0.0",
+        "schema-utils": "0.4.5",
+        "serialize-javascript": "1.5.0",
+        "source-map": "0.6.1",
+        "uglify-es": "3.3.9",
+        "webpack-sources": "1.1.0",
+        "worker-farm": "1.6.0"
       },
       "dependencies": {
         "commander": {
@@ -13333,8 +13334,8 @@
           "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
           "dev": true,
           "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
+            "commander": "2.13.0",
+            "source-map": "0.6.1"
           }
         }
       }
@@ -13357,8 +13358,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -13379,10 +13380,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -13391,7 +13392,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -13400,10 +13401,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -13426,7 +13427,7 @@
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "dev": true,
       "requires": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "2.0.0"
       }
     },
     "unique-slug": {
@@ -13435,7 +13436,7 @@
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "requires": {
-        "imurmurhash": "^0.1.4"
+        "imurmurhash": "0.1.4"
       }
     },
     "unpipe": {
@@ -13450,8 +13451,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -13460,9 +13461,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -13508,7 +13509,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -13547,8 +13548,8 @@
       "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "dev": true,
       "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.0.0",
+        "requires-port": "1.0.0"
       }
     },
     "url-parse-lax": {
@@ -13557,7 +13558,7 @@
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "^2.0.0"
+        "prepend-http": "2.0.0"
       },
       "dependencies": {
         "prepend-http": {
@@ -13601,8 +13602,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.2",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "utila": {
@@ -13635,8 +13636,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vary": {
@@ -13657,9 +13658,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vinyl": {
@@ -13668,8 +13669,8 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -13679,12 +13680,12 @@
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.3.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^2.0.0",
-        "vinyl": "^1.1.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "2.0.0",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "pify": {
@@ -13699,7 +13700,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -13719,7 +13720,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "^0.1.2"
+        "browser-process-hrtime": "0.1.2"
       }
     },
     "walker": {
@@ -13728,7 +13729,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "watch": {
@@ -13737,8 +13738,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "exec-sh": "0.2.2",
+        "minimist": "1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -13755,9 +13756,9 @@
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "chokidar": "2.0.4",
+        "graceful-fs": "4.1.11",
+        "neo-async": "2.5.2"
       }
     },
     "wbuf": {
@@ -13766,7 +13767,7 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "1.0.1"
       }
     },
     "webidl-conversions": {
@@ -13786,26 +13787,26 @@
         "@webassemblyjs/wasm-edit": "1.5.13",
         "@webassemblyjs/wasm-opt": "1.5.13",
         "@webassemblyjs/wasm-parser": "1.5.13",
-        "acorn": "^5.6.2",
-        "acorn-dynamic-import": "^3.0.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chrome-trace-event": "^1.0.0",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.0",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "micromatch": "^3.1.8",
-        "mkdirp": "~0.5.0",
-        "neo-async": "^2.5.0",
-        "node-libs-browser": "^2.0.0",
-        "schema-utils": "^0.4.4",
-        "tapable": "^1.0.0",
-        "uglifyjs-webpack-plugin": "^1.2.4",
-        "watchpack": "^1.5.0",
-        "webpack-sources": "^1.0.1"
+        "acorn": "5.7.2",
+        "acorn-dynamic-import": "3.0.0",
+        "ajv": "6.5.0",
+        "ajv-keywords": "3.2.0",
+        "chrome-trace-event": "1.0.0",
+        "enhanced-resolve": "4.1.0",
+        "eslint-scope": "4.0.0",
+        "json-parse-better-errors": "1.0.2",
+        "loader-runner": "2.3.0",
+        "loader-utils": "1.1.0",
+        "memory-fs": "0.4.1",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "neo-async": "2.5.2",
+        "node-libs-browser": "2.1.0",
+        "schema-utils": "0.4.5",
+        "tapable": "1.0.0",
+        "uglifyjs-webpack-plugin": "1.3.0",
+        "watchpack": "1.6.0",
+        "webpack-sources": "1.1.0"
       }
     },
     "webpack-addons": {
@@ -13814,7 +13815,7 @@
       "integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
       "dev": true,
       "requires": {
-        "jscodeshift": "^0.4.0"
+        "jscodeshift": "0.4.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -13823,7 +13824,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -13850,9 +13851,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "core-js": {
@@ -13873,7 +13874,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -13882,7 +13883,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -13897,7 +13898,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "jscodeshift": {
@@ -13906,21 +13907,21 @@
           "integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
           "dev": true,
           "requires": {
-            "async": "^1.5.0",
-            "babel-plugin-transform-flow-strip-types": "^6.8.0",
-            "babel-preset-es2015": "^6.9.0",
-            "babel-preset-stage-1": "^6.5.0",
-            "babel-register": "^6.9.0",
-            "babylon": "^6.17.3",
-            "colors": "^1.1.2",
-            "flow-parser": "^0.*",
-            "lodash": "^4.13.1",
-            "micromatch": "^2.3.7",
+            "async": "1.5.2",
+            "babel-plugin-transform-flow-strip-types": "6.22.0",
+            "babel-preset-es2015": "6.24.1",
+            "babel-preset-stage-1": "6.24.1",
+            "babel-register": "6.26.0",
+            "babylon": "6.18.0",
+            "colors": "1.1.2",
+            "flow-parser": "0.79.1",
+            "lodash": "4.17.10",
+            "micromatch": "2.3.11",
             "node-dir": "0.1.8",
-            "nomnom": "^1.8.1",
-            "recast": "^0.12.5",
-            "temp": "^0.8.1",
-            "write-file-atomic": "^1.2.0"
+            "nomnom": "1.8.1",
+            "recast": "0.12.9",
+            "temp": "0.8.3",
+            "write-file-atomic": "1.3.4"
           }
         },
         "kind-of": {
@@ -13929,7 +13930,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -13938,19 +13939,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         },
         "recast": {
@@ -13960,10 +13961,10 @@
           "dev": true,
           "requires": {
             "ast-types": "0.10.1",
-            "core-js": "^2.4.1",
-            "esprima": "~4.0.0",
-            "private": "~0.1.5",
-            "source-map": "~0.6.1"
+            "core-js": "2.5.7",
+            "esprima": "4.0.1",
+            "private": "0.1.8",
+            "source-map": "0.6.1"
           }
         },
         "source-map": {
@@ -13980,32 +13981,32 @@
       "integrity": "sha512-CiWQR+1JS77rmyiO6y1q8Kt/O+e8nUUC9YfJ25JtSmzDwbqJV7vIsh3+QKRHVTbTCa0DaVh8iY1LBiagUIDB3g==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "cross-spawn": "^6.0.5",
-        "diff": "^3.5.0",
-        "enhanced-resolve": "^4.0.0",
-        "envinfo": "^5.7.0",
-        "glob-all": "^3.1.0",
-        "global-modules": "^1.0.0",
-        "got": "^8.3.1",
-        "import-local": "^1.0.0",
-        "inquirer": "^5.2.0",
-        "interpret": "^1.1.0",
-        "jscodeshift": "^0.5.0",
-        "listr": "^0.14.1",
-        "loader-utils": "^1.1.0",
-        "lodash": "^4.17.10",
-        "log-symbols": "^2.2.0",
-        "mkdirp": "^0.5.1",
-        "p-each-series": "^1.0.0",
-        "p-lazy": "^1.0.0",
-        "prettier": "^1.12.1",
-        "supports-color": "^5.4.0",
-        "v8-compile-cache": "^2.0.0",
-        "webpack-addons": "^1.1.5",
-        "yargs": "^11.1.0",
-        "yeoman-environment": "^2.1.1",
-        "yeoman-generator": "^2.0.5"
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "diff": "3.5.0",
+        "enhanced-resolve": "4.1.0",
+        "envinfo": "5.10.0",
+        "glob-all": "3.1.0",
+        "global-modules": "1.0.0",
+        "got": "8.3.2",
+        "import-local": "1.0.0",
+        "inquirer": "5.2.0",
+        "interpret": "1.1.0",
+        "jscodeshift": "0.5.1",
+        "listr": "0.14.1",
+        "loader-utils": "1.1.0",
+        "lodash": "4.17.10",
+        "log-symbols": "2.2.0",
+        "mkdirp": "0.5.1",
+        "p-each-series": "1.0.0",
+        "p-lazy": "1.0.0",
+        "prettier": "1.14.3",
+        "supports-color": "5.4.0",
+        "v8-compile-cache": "2.0.2",
+        "webpack-addons": "1.1.5",
+        "yargs": "11.1.0",
+        "yeoman-environment": "2.3.3",
+        "yeoman-generator": "2.0.5"
       }
     },
     "webpack-dev-middleware": {
@@ -14014,13 +14015,13 @@
       "integrity": "sha512-YJLMF/96TpKXaEQwaLEo+Z4NDK8aV133ROF6xp9pe3gQoS7sxfpXh4Rv9eC+8vCvWfmDjRQaMSlRPbO+9G6jgA==",
       "dev": true,
       "requires": {
-        "loud-rejection": "^1.6.0",
-        "memory-fs": "~0.4.1",
-        "mime": "^2.3.1",
-        "path-is-absolute": "^1.0.0",
-        "range-parser": "^1.0.3",
-        "url-join": "^4.0.0",
-        "webpack-log": "^2.0.0"
+        "loud-rejection": "1.6.0",
+        "memory-fs": "0.4.1",
+        "mime": "2.3.1",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0",
+        "url-join": "4.0.0",
+        "webpack-log": "2.0.0"
       },
       "dependencies": {
         "mime": {
@@ -14038,31 +14039,31 @@
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
-        "bonjour": "^3.5.0",
-        "chokidar": "^2.0.0",
-        "compression": "^1.5.2",
-        "connect-history-api-fallback": "^1.3.0",
-        "debug": "^3.1.0",
-        "del": "^3.0.0",
-        "express": "^4.16.2",
-        "html-entities": "^1.2.0",
-        "http-proxy-middleware": "~0.18.0",
-        "import-local": "^1.0.0",
+        "bonjour": "3.5.0",
+        "chokidar": "2.0.4",
+        "compression": "1.7.3",
+        "connect-history-api-fallback": "1.5.0",
+        "debug": "3.1.0",
+        "del": "3.0.0",
+        "express": "4.16.3",
+        "html-entities": "1.2.1",
+        "http-proxy-middleware": "0.18.0",
+        "import-local": "1.0.0",
         "internal-ip": "1.2.0",
-        "ip": "^1.1.5",
-        "killable": "^1.0.0",
-        "loglevel": "^1.4.1",
-        "opn": "^5.1.0",
-        "portfinder": "^1.0.9",
-        "selfsigned": "^1.9.1",
-        "serve-index": "^1.7.2",
+        "ip": "1.1.5",
+        "killable": "1.0.0",
+        "loglevel": "1.6.1",
+        "opn": "5.3.0",
+        "portfinder": "1.0.17",
+        "selfsigned": "1.10.3",
+        "serve-index": "1.9.1",
         "sockjs": "0.3.19",
         "sockjs-client": "1.1.5",
-        "spdy": "^3.4.1",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^5.1.0",
+        "spdy": "3.4.7",
+        "strip-ansi": "3.0.1",
+        "supports-color": "5.4.0",
         "webpack-dev-middleware": "3.2.0",
-        "webpack-log": "^2.0.0",
+        "webpack-log": "2.0.0",
         "yargs": "12.0.1"
       },
       "dependencies": {
@@ -14096,7 +14097,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "locate-path": {
@@ -14105,8 +14106,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -14115,7 +14116,7 @@
           "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.0.0"
           }
         },
         "p-locate": {
@@ -14124,7 +14125,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.0.0"
           }
         },
         "p-try": {
@@ -14139,7 +14140,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "yargs": {
@@ -14148,18 +14149,18 @@
           "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^2.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^10.1.0"
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "10.1.0"
           }
         },
         "yargs-parser": {
@@ -14168,7 +14169,7 @@
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -14179,8 +14180,8 @@
       "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
+        "ansi-colors": "3.0.5",
+        "uuid": "3.3.2"
       }
     },
     "webpack-sources": {
@@ -14189,8 +14190,8 @@
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
       "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+        "source-list-map": "2.0.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -14207,8 +14208,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0",
-        "websocket-extensions": ">=0.1.1"
+        "http-parser-js": "0.4.13",
+        "websocket-extensions": "0.1.3"
       }
     },
     "websocket-extensions": {
@@ -14232,7 +14233,7 @@
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         }
       }
@@ -14255,9 +14256,9 @@
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "whet.extend": {
@@ -14272,7 +14273,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -14300,7 +14301,7 @@
       "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
       "dev": true,
       "requires": {
-        "errno": "~0.1.7"
+        "errno": "0.1.7"
       }
     },
     "wrap-ansi": {
@@ -14309,8 +14310,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14325,7 +14326,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -14334,9 +14335,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -14345,7 +14346,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -14362,9 +14363,9 @@
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
       }
     },
     "ws": {
@@ -14373,7 +14374,7 @@
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "1.0.0"
       }
     },
     "xml-name-validator": {
@@ -14412,18 +14413,18 @@
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "9.0.2"
       },
       "dependencies": {
         "y18n": {
@@ -14440,7 +14441,7 @@
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "4.1.0"
       }
     },
     "yeoman-environment": {
@@ -14449,21 +14450,21 @@
       "integrity": "sha512-HBpXdNw8V66EwqIFt01rNhSgX33BOzgVb9CxpIvESvCI4ELeOSniB6gV6RXwrBur8kmHZCIAkYQYpib7Qxx8FQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "diff": "^3.5.0",
-        "escape-string-regexp": "^1.0.2",
-        "globby": "^8.0.1",
-        "grouped-queue": "^0.3.3",
-        "inquirer": "^6.0.0",
-        "is-scoped": "^1.0.0",
-        "lodash": "^4.17.10",
-        "log-symbols": "^2.2.0",
-        "mem-fs": "^1.1.0",
-        "strip-ansi": "^4.0.0",
-        "text-table": "^0.2.0",
-        "untildify": "^3.0.3"
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "globby": "8.0.1",
+        "grouped-queue": "0.3.3",
+        "inquirer": "6.2.0",
+        "is-scoped": "1.0.0",
+        "lodash": "4.17.10",
+        "log-symbols": "2.2.0",
+        "mem-fs": "1.1.3",
+        "strip-ansi": "4.0.0",
+        "text-table": "0.2.0",
+        "untildify": "3.0.3"
       },
       "dependencies": {
         "chardet": {
@@ -14487,9 +14488,9 @@
           "integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
           "dev": true,
           "requires": {
-            "chardet": "^0.5.0",
-            "iconv-lite": "^0.4.22",
-            "tmp": "^0.0.33"
+            "chardet": "0.5.0",
+            "iconv-lite": "0.4.24",
+            "tmp": "0.0.33"
           }
         },
         "inquirer": {
@@ -14498,19 +14499,19 @@
           "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.10",
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "3.0.1",
+            "figures": "2.0.0",
+            "lodash": "4.17.10",
             "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.1.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
+            "run-async": "2.3.0",
+            "rxjs": "6.2.2",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
           }
         },
         "rxjs": {
@@ -14519,7 +14520,7 @@
           "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
           "dev": true,
           "requires": {
-            "tslib": "^1.9.0"
+            "tslib": "1.9.3"
           }
         }
       }
@@ -14530,31 +14531,31 @@
       "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "chalk": "^2.3.0",
-        "cli-table": "^0.3.1",
-        "cross-spawn": "^6.0.5",
-        "dargs": "^5.1.0",
-        "dateformat": "^3.0.3",
-        "debug": "^3.1.0",
-        "detect-conflict": "^1.0.0",
-        "error": "^7.0.2",
-        "find-up": "^2.1.0",
-        "github-username": "^4.0.0",
-        "istextorbinary": "^2.2.1",
-        "lodash": "^4.17.10",
-        "make-dir": "^1.1.0",
-        "mem-fs-editor": "^4.0.0",
-        "minimist": "^1.2.0",
-        "pretty-bytes": "^4.0.2",
-        "read-chunk": "^2.1.0",
-        "read-pkg-up": "^3.0.0",
-        "rimraf": "^2.6.2",
-        "run-async": "^2.0.0",
-        "shelljs": "^0.8.0",
-        "text-table": "^0.2.0",
-        "through2": "^2.0.0",
-        "yeoman-environment": "^2.0.5"
+        "async": "2.6.1",
+        "chalk": "2.4.1",
+        "cli-table": "0.3.1",
+        "cross-spawn": "6.0.5",
+        "dargs": "5.1.0",
+        "dateformat": "3.0.3",
+        "debug": "3.1.0",
+        "detect-conflict": "1.0.1",
+        "error": "7.0.2",
+        "find-up": "2.1.0",
+        "github-username": "4.1.0",
+        "istextorbinary": "2.2.1",
+        "lodash": "4.17.10",
+        "make-dir": "1.3.0",
+        "mem-fs-editor": "4.0.3",
+        "minimist": "1.2.0",
+        "pretty-bytes": "4.0.2",
+        "read-chunk": "2.1.0",
+        "read-pkg-up": "3.0.0",
+        "rimraf": "2.6.2",
+        "run-async": "2.3.0",
+        "shelljs": "0.8.2",
+        "text-table": "0.2.0",
+        "through2": "2.0.3",
+        "yeoman-environment": "2.3.3"
       },
       "dependencies": {
         "async": {
@@ -14563,7 +14564,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.10"
           }
         },
         "debug": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "html-webpack-plugin": "^3.2.0",
     "husky": "^1.1.2",
     "jest": "^23.5.0",
-    "jest-get-type": "^22.4.3",
     "lint-staged": "^7.3.0",
     "prettier": "^1.14.3",
     "raf": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
   },
   "keywords": [],
   "license": "MIT",
-  "dependencies": {
-    "jest-get-type": "^22.4.3"
-  },
   "peerDependencies": {
     "react": ">15",
     "react-dom": ">15"
@@ -34,6 +31,7 @@
     "html-webpack-plugin": "^3.2.0",
     "husky": "^1.1.2",
     "jest": "^23.5.0",
+    "jest-get-type": "^22.4.3",
     "lint-staged": "^7.3.0",
     "prettier": "^1.14.3",
     "raf": "^3.4.0",

--- a/src/lib/convertStyle/convertStyle.js
+++ b/src/lib/convertStyle/convertStyle.js
@@ -1,5 +1,3 @@
-import getType from 'jest-get-type';
-
 export function containsRvh(propertyValue) {
   // TODO: when regexp is lifted up the lexical scope, to be used
   // in both `containsRvh` and `replaceRvhWithPx`, some tests start to
@@ -20,7 +18,7 @@ function replaceRvhWithPx(propertyStringValue, windowHeight) {
 }
 
 function throwOnBadArgs(givenStyle, windowHeight) {
-  if (getType(givenStyle) !== 'object' && givenStyle !== undefined)
+  if (typeof givenStyle !== 'object' && givenStyle !== undefined)
     throw Error(`style (the first argument) must be an object or undefined`);
   if (typeof windowHeight !== 'number' || windowHeight < 0)
     throw Error('Second argument (windowHeight) must be a non-negative number');


### PR DESCRIPTION
Hi,
   I removed the jest-get-type dependency because this library is not for production build.

Compiling it in my web app project breaks the compatibility with IE11 and old Chrome (like 41).

Thanks
Marco