### PR TITLE
Allow non-string type for string value

### DIFF
--- a/src/lib/convertStyle/convertStyle.js
+++ b/src/lib/convertStyle/convertStyle.js
@@ -37,7 +37,10 @@ function convertStyle(givenStyle, windowHeight) {
   Object.keys(usedStyle).forEach(key => {
     // if a value contains no rvh unit, it's used as is, otherwise converted
     // to px; 1rvh = (window.innerHeight / 100)px
-    convertedStyle[key] = replaceRvhWithPx(usedStyle[key], windowHeight);
+    convertedStyle[key] =
+      typeof usedStyle[key] === 'string'
+        ? replaceRvhWithPx(usedStyle[key], windowHeight)
+        : usedStyle[key];
   });
   return convertedStyle;
 }

--- a/src/lib/convertStyle/convertStyle.test.js
+++ b/src/lib/convertStyle/convertStyle.test.js
@@ -40,6 +40,13 @@ describe('rvh conversion', () => {
     expect(() => convertStyle({}, 1000)).not.toThrow();
   });
 
+  it('supports non-string value as style value', () => {
+    expect(convertStyle({ lineHeight: 2, height: '50rvh' }, 1000)).toEqual({
+      lineHeight: 2,
+      height: '500px'
+    });
+  });
+
   it('converts rvh to px', () => {
     expect(convertStyle({ height: '100rvh' }, 1000)).toEqual({
       height: '1000px'


### PR DESCRIPTION
I think that library should ignore non-string types in style value. Now It throws if you pass { margin: 5, height: '50rvh' } as style to Div100vh component.