### PR TITLE
Add support for non-div elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ The rest of the props are passed unchanged to the underlying `div` that `Div100v
 
 ### Rendering non-`<div>` elements
 
-You can also pass an `el` prop to render other elements than `<div>`s - for example, `<main>`, `<section>`, `<footer>`, et cetera. 
+You can also pass an `as` prop to render other elements than `<div>`s - for example, `<main>`, `<section>`, `<footer>`, et cetera. 
 
 ```jsx
-<Div100vh el="main">
+<Div100vh as="main">
   <p>Some main content</p>
 </Div100vh>
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ If you do pass anything to the `style` prop, no implicit style is applied. You c
 
 The rest of the props are passed unchanged to the underlying `div` that `Div100vh` renders.
 
+
+### Rendering non-`<div>` elements
+
+You can also pass an `el` prop to render other elements than `<div>`s - for example, `<main>`, `<section>`, `<footer>`, et cetera. 
+
+```jsx
+<Div100vh el="main">
+  <p>Some main content</p>
+</Div100vh>
+```
+
+> ❗ Keep in mind that this works best with [block-level elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements), as inline-level elements don't respond to the CSS `height` property. 
+
 ## Additional considerations
 
 Please note that most likely you will want to set `body {margin: 0}` css, unless you use some css reset that does it for you.

--- a/src/lib/Div100vh.js
+++ b/src/lib/Div100vh.js
@@ -4,7 +4,7 @@ import getWindowHeight from './getWindowHeight';
 
 export default class Div100vh extends React.Component {
   state = {
-    style: {},
+    style: {}
   };
 
   // On mount and window resize converts rvh values to px (if there are any).

--- a/src/lib/Div100vh.js
+++ b/src/lib/Div100vh.js
@@ -24,6 +24,8 @@ export default class Div100vh extends React.Component {
   }
 
   render() {
-    return <div {...this.props} style={this.state.style} />;
+    const { el: El = 'div', ...props } = this.props;
+
+    return <El {...props} style={this.state.style} />;
   }
 }

--- a/src/lib/Div100vh.js
+++ b/src/lib/Div100vh.js
@@ -4,7 +4,7 @@ import getWindowHeight from './getWindowHeight';
 
 export default class Div100vh extends React.Component {
   state = {
-    style: {}
+    style: {},
   };
 
   // On mount and window resize converts rvh values to px (if there are any).
@@ -24,8 +24,8 @@ export default class Div100vh extends React.Component {
   }
 
   render() {
-    const { el: El = 'div', ...props } = this.props;
+    const { as: Element = 'div', ...props } = this.props;
 
-    return <El {...props} style={this.state.style} />;
+    return <Element {...props} style={this.state.style} />;
   }
 }

--- a/src/lib/Div100vh.test.js
+++ b/src/lib/Div100vh.test.js
@@ -41,14 +41,14 @@ describe('rvh unit conversion', () => {
   });
   it('converts a shorthand value with multiple rvh entries', () => {
     const component = renderComponent({
-      style: { margin: '1rvh 2px 1.5rvh 3%' },
+      style: { margin: '1rvh 2px 1.5rvh 3%' }
     });
     const props = getDivProps(component);
     expect(props).toEqual({ style: { margin: '10px 2px 15px 3%' } });
   });
   it('converts an rvh value and passes through other style props', () => {
     const component = renderComponent({
-      style: { fontSize: '5rvh', color: 'red' },
+      style: { fontSize: '5rvh', color: 'red' }
     });
     const props = getDivProps(component);
     expect(props).toEqual({ style: { fontSize: '50px', color: 'red' } });

--- a/src/lib/Div100vh.test.js
+++ b/src/lib/Div100vh.test.js
@@ -41,14 +41,14 @@ describe('rvh unit conversion', () => {
   });
   it('converts a shorthand value with multiple rvh entries', () => {
     const component = renderComponent({
-      style: { margin: '1rvh 2px 1.5rvh 3%' }
+      style: { margin: '1rvh 2px 1.5rvh 3%' },
     });
     const props = getDivProps(component);
     expect(props).toEqual({ style: { margin: '10px 2px 15px 3%' } });
   });
   it('converts an rvh value and passes through other style props', () => {
     const component = renderComponent({
-      style: { fontSize: '5rvh', color: 'red' }
+      style: { fontSize: '5rvh', color: 'red' },
     });
     const props = getDivProps(component);
     expect(props).toEqual({ style: { fontSize: '50px', color: 'red' } });
@@ -75,7 +75,7 @@ describe('rendering elements other than divs', () => {
 
   it('renders a non-div element passed in as a prop', () => {
     const type = 'main';
-    const component = renderComponent({ el: type });
+    const component = renderComponent({ as: type });
     expect(component.root.findByType(type)).toBeTruthy();
   });
 });

--- a/src/lib/Div100vh.test.js
+++ b/src/lib/Div100vh.test.js
@@ -66,3 +66,16 @@ it('passes through to the underlying div the other props without rvh', () => {
   const props = getDivProps(component);
   expect(props).toEqual({ foo: 'bar', style: { color: 'red' } });
 });
+
+describe('rendering elements other than divs', () => {
+  it('renders a div if no el prop is passed in', () => {
+    const component = renderComponent({});
+    expect(component.root.findByType('div')).toBeTruthy();
+  });
+
+  it('renders a non-div element passed in as a prop', () => {
+    const type = 'main';
+    const component = renderComponent({ el: type });
+    expect(component.root.findByType(type)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
I'm using this package on a site but wanted to render an `<aside>` element instead of a div; having a div either wrapping or sitting just inside of the `<aside>` tends to clutter up the code. So I've added support for rendering arbitrary elements instead of only `<div>`s. It should help to make code a little more, like, semantically navigable.

Please let me know if I've missed out anything in this PR. I think the functionality is pretty simple but there's always a chance I've missed something significant.