### PR TITLE
Apply the styles on the first render

### DIFF
--- a/src/lib/Div100vh.js
+++ b/src/lib/Div100vh.js
@@ -3,9 +3,12 @@ import convertStyle from './convertStyle';
 import getWindowHeight from './getWindowHeight';
 
 export default class Div100vh extends React.Component {
-  state = {
-    style: {}
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      style: convertStyle(props.style, getWindowHeight())
+    };
+  }
 
   // On mount and window resize converts rvh values to px (if there are any).
   // Also, adds `height: 100rvh` if height is not specified at all
@@ -15,7 +18,6 @@ export default class Div100vh extends React.Component {
   };
 
   componentDidMount() {
-    this.updateStyle();
     window.addEventListener('resize', this.updateStyle);
   }
 

--- a/src/lib/Div100vh.test.js
+++ b/src/lib/Div100vh.test.js
@@ -79,3 +79,10 @@ describe('rendering elements other than divs', () => {
     expect(component.root.findByType(type)).toBeTruthy();
   });
 });
+
+it('applies the style to the first render', () => {
+  const component = new Div100vh({ style: { height: '50.5rvh' } });
+  const firstRenderedComponent = renderer.create(component.render());
+  const props = firstRenderedComponent.root.props;
+  expect(props).toEqual({ style: { height: '505px' } });
+});


### PR DESCRIPTION
My project is using the calculated height of the Div100vh element to determine how much data to fetch from a server, but since the initial render didn't yet have the styles applied it was fetching a small amount of data first (default height of div) and then making a second request for the full amount after the styles were applied.

To avoid an unnecessary re-render (and in my case, the unnecessary second http request), my pull request applies the styles to the first render.