### PR TITLE
Fix SSR and building in node-environments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.3.7 (Dec 13, 2019)
-* Fix 'error "document" is not available during server side rendering.' (@kyleboss-tinder in [27](https://github.com/mvasin/react-div-100vh/pull/28))
+* Fix 'error "document" is not available during server side rendering.' (@kyleboss-tinder in [28](https://github.com/mvasin/react-div-100vh/pull/28))
 
 ## 0.3.6 (Dec 10, 2019)
 * Use document.documentElement.clientHeight instead of window.innerHeight (@meyerds in [26](https://github.com/mvasin/react-div-100vh/pull/26))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.3.7 (Dec 13, 2019)
-* Fix 'error "document" is not available during server side rendering.' (@kyleboss-tinder in [27](https://github.com/mvasin/react-div-100vh/pull/27))
+* Fix 'error "document" is not available during server side rendering.' (@kyleboss-tinder in [27](https://github.com/mvasin/react-div-100vh/pull/28))
 
 ## 0.3.6 (Dec 10, 2019)
 * Use document.documentElement.clientHeight instead of window.innerHeight (@meyerds in [26](https://github.com/mvasin/react-div-100vh/pull/26))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.7 (Dec 13, 2019)
+* Fix 'error "document" is not available during server side rendering.' (@kyleboss-tinder in [27](https://github.com/mvasin/react-div-100vh/pull/27))
+
 ## 0.3.6 (Dec 10, 2019)
 * Use document.documentElement.clientHeight instead of window.innerHeight (@meyerds in [26](https://github.com/mvasin/react-div-100vh/pull/26))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-div-100vh",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A React component that aims to solve '100vh' issue in mobile browsers",
   "main": "lib/index.js",
   "scripts": {

--- a/src/lib/getWindowHeight/getWindowHeight.js
+++ b/src/lib/getWindowHeight/getWindowHeight.js
@@ -1,5 +1,8 @@
-// extracted into a separate module so it's easier to mock with Jest
 function getWindowHeight() {
+  if (typeof document === 'undefined' && typeof window === 'undefined') {
+    return 0;
+  }
+
   return (document && document.documentElement && document.documentElement.clientHeight) || window.innerHeight;
 }
 

--- a/src/lib/getWindowHeight/getWindowHeight.test.js
+++ b/src/lib/getWindowHeight/getWindowHeight.test.js
@@ -1,0 +1,33 @@
+import getWindowHeight from '.';
+import { JSDOM } from 'jsdom';
+
+describe('the document exists', () => {
+  beforeEach(() => {
+    jest.spyOn(document.documentElement, 'clientHeight', 'get').mockImplementation(() => 100);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns document.documentElement.clientHeight', () => {
+    const windowHeight = getWindowHeight();
+    expect(windowHeight).toEqual(100);
+  });
+});
+
+describe('the window exists', () => {
+  beforeEach(() => {
+    jest.spyOn(document.documentElement, 'clientHeight', 'get').mockImplementation(() => undefined);
+    window = Object.assign(window, { document: undefined, innerHeight: 500 });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns window.innerHeight', () => {
+    const windowHeight = getWindowHeight();
+    expect(windowHeight).toEqual(500);
+  });
+});

--- a/src/lib/getWindowHeight/getWindowHeightInNode.test.js
+++ b/src/lib/getWindowHeight/getWindowHeightInNode.test.js
@@ -1,0 +1,12 @@
+/**
+ * @jest-environment node
+ */
+
+import getWindowHeight from '.';
+
+describe('neither document nor window exists, e.g. server-side rendering', () => {
+  it('returns 0', () => {
+    const windowHeight = getWindowHeight();
+    expect(windowHeight).toEqual(0);
+  });
+});

--- a/src/lib/getWindowHeight/index.js
+++ b/src/lib/getWindowHeight/index.js
@@ -1,0 +1,1 @@
+export { default } from './getWindowHeight';


### PR DESCRIPTION
`getWindowHeight` now returns 0 when `document` and `window` do not exist.

This will solve issues for those who are server-side rendering or
building in a node environment.

Added tests.

Fixes #27 