### PR TITLE
Add typescript declarations to dists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.3 (Sep 24, 2020)
+
+- Adds typescript declarations to dist (@tachnik)
+
 ## 0.5.0 (Aug 27, 2020)
 
 - [BREAKING CHANGE] `use100vh` returns `null` in Node (when server-side rendered)(@mvasin)

--- a/packages/react-div-100vh/package.json
+++ b/packages/react-div-100vh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-div-100vh",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "description": "A workaround for the '100vh' issue in mobile browsers",
   "license": "MIT",
   "main": "dist/cjs/index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "declaration": true
   }
 }


### PR DESCRIPTION
They seem to be missing in `node_modules/react-div-100vh/dist/cjs`. I think this fixes it