### PR TITLE
Small optimizations

### DIFF
--- a/packages/react-div-100vh/src/index.tsx
+++ b/packages/react-div-100vh/src/index.tsx
@@ -32,12 +32,12 @@ export function use100vh(): number | null {
 
     function setMeasuredHeight() {
       const measuredHeight = measureHeight()
-      if (height !== measuredHeight) setHeight(measuredHeight)
+      setHeight(measuredHeight)
     }
 
     window.addEventListener('resize', setMeasuredHeight)
     return () => window.removeEventListener('resize', setMeasuredHeight)
-  }, [height, wasRenderedOnClientAtLeastOnce])
+  }, [wasRenderedOnClientAtLeastOnce])
   return wasRenderedOnClientAtLeastOnce ? height : null
 }
 
@@ -57,10 +57,10 @@ function useWasRenderedOnClientAtLeastOnce() {
   ] = useState(false)
 
   useEffect(() => {
-    if (isClient() && !wasRenderedOnClientAtLeastOnce) {
+    if (isClient()) {
       setWasRenderedOnClientAtLeastOnce(true)
     }
-  }, [wasRenderedOnClientAtLeastOnce])
+  }, [])
   return wasRenderedOnClientAtLeastOnce
 }
 

--- a/packages/react-div-100vh/src/index.tsx
+++ b/packages/react-div-100vh/src/index.tsx
@@ -23,7 +23,7 @@ export default function Div100vh({
 }
 
 export function use100vh(): number | null {
-  const [height, setHeight] = useState<number | null>(measureHeight())
+  const [height, setHeight] = useState<number | null>(measureHeight)
 
   const wasRenderedOnClientAtLeastOnce = useWasRenderedOnClientAtLeastOnce()
 


### PR DESCRIPTION
- prevent calling `measureHeight()` on every render - [reference](https://reactjs.org/docs/hooks-reference.html#lazy-initial-state)
- prevent re-setting event listeners on every resize 
  [reference](https://reactjs.org/docs/hooks-reference.html#functional-updates)
  > “If your update function returns the exact same value as the current state, the subsequent rerender will be skipped completely.”