### PR TITLE
doc: change exported function name in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ const MyHalfHeightExampleComponent = ({ children }) => {
 }
 ```
 
-Under the hood `use100vh` uses `getRealHeight` function which is exported as
+Under the hood `use100vh` uses `measureHeight` function which is exported as
 well, so feel free to use it, even without React. Currently it returns
-`document.documentElement?.clientHeight || window.innerHeight`.
+`document.documentElement?.clientHeight || window.innerHeight` or `null`.
 
 ## Testing
 

--- a/packages/react-div-100vh/README.md
+++ b/packages/react-div-100vh/README.md
@@ -59,9 +59,9 @@ const MyHalfHeightExampleComponent = ({ children }) => {
 }
 ```
 
-Under the hood `use100vh` uses `getRealHeight` function which is exported as
+Under the hood `use100vh` uses `measureHeight` function which is exported as
 well, so feel free to use it, even without React. Currently it returns
-`document.documentElement?.clientHeight || window.innerHeight`.
+`document.documentElement?.clientHeight || window.innerHeight` or `null`.
 
 ## Testing
 

--- a/packages/test-app/index.html
+++ b/packages/test-app/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="React hook that helps to avoid 100vh issue on mobile"
     />
-    <title>useRealHeight</title>
+    <title>measureHeight</title>
     <style>
       body {
         background: #eee;


### PR DESCRIPTION
Hey! I tried using the lib and got an error about the `getRealHeight` function which does not exist. Checked out the source code, and realized that now it's called `measureHeight`, so I took the liberty to change it to the current one in both README files and sample application index.html. No actual code changes, so it's safe to merge, I suppose. Thanks for the lib. 🤝 