### PR TITLE
Support ref forwarding

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,10 @@
     "sourceType": "module"
   },
   "plugins": ["react", "@typescript-eslint"],
-  "rules": {},
+  "rules": {
+    "react/display-name": 0,
+    "react/prop-types": 0
+  },
   "settings": {
     "react": {
       "version": "detect"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,6 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    "react/display-name": 0,
     "react/prop-types": 0
   },
   "settings": {

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dist
 
 # Yarn
 yarn-error.log
+
+.DS_Store

--- a/packages/react-div-100vh/src/index.tsx
+++ b/packages/react-div-100vh/src/index.tsx
@@ -1,26 +1,27 @@
-import React, { useState, useEffect, HTMLAttributes } from 'react'
+import React, { forwardRef, useState, useEffect, HTMLAttributes } from 'react'
 
 let warned = false
 
-export default function Div100vh({
-  style = {},
-  ...other
-}: HTMLAttributes<HTMLDivElement>): JSX.Element {
-  const height = use100vh()
+const Div100vh = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ style, ...other }, ref) => {
+    const height = use100vh()
 
-  // TODO: warn only in development
-  if (!warned && style.height) {
-    warned = true
-    console.warn(
-      '<ReactDiv100vh /> overrides the height property of the style prop'
-    )
+    // TODO: warn only in development
+    if (!warned && style?.height) {
+      warned = true
+      console.warn(
+        '<ReactDiv100vh /> overrides the height property of the style prop'
+      )
+    }
+    const styleWithRealHeight = {
+      ...style,
+      height: height ? `${height}px` : '100vh'
+    }
+    return <div ref={ref} style={styleWithRealHeight} {...other} />
   }
-  const styleWithRealHeight = {
-    ...style,
-    height: height ? `${height}px` : '100vh'
-  }
-  return <div style={styleWithRealHeight} {...other} />
-}
+)
+
+export default Div100vh
 
 export function use100vh(): number | null {
   const [height, setHeight] = useState<number | null>(measureHeight)

--- a/packages/react-div-100vh/src/index.tsx
+++ b/packages/react-div-100vh/src/index.tsx
@@ -21,6 +21,8 @@ const Div100vh = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   }
 )
 
+Div100vh.displayName = 'Div100vh'
+
 export default Div100vh
 
 export function use100vh(): number | null {

--- a/packages/react-div-100vh/src/jsdom.test.tsx
+++ b/packages/react-div-100vh/src/jsdom.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
 import Div100vh from '.'
 import { act } from 'react-dom/test-utils'
@@ -58,5 +58,38 @@ describe('Div100vh component', () => {
       (args) => args[0] === 'resize'
     )
     expect(resizeListenerUnmountCalls.length).toBe(1)
+  })
+
+  it('forwards ref', () => {
+    let focus: () => void
+    const TestApp = () => {
+      const ref = useRef<HTMLDivElement>(null)
+      focus = () => {
+        ref.current?.focus()
+      }
+      return (
+        <Div100vh
+          ref={ref}
+          // so we look up the target div by different means (not via the ref)
+          data-test
+          // https://github.com/jsdom/jsdom/issues/2586#issuecomment-561871527
+          tabIndex={1}
+        >
+          hello
+        </Div100vh>
+      )
+    }
+    act(() => {
+      render(<TestApp />, container)
+    })
+
+    const divElement = container?.querySelector('[data-test]')
+    expect(document.activeElement === divElement).toBe(false)
+
+    act(() => {
+      focus()
+    })
+
+    expect(document.activeElement === divElement).toBe(true)
   })
 })


### PR DESCRIPTION
This lets users hook a ref to the inner `div` for maximum flexibility. Totally backwards compatible change, too!