### PR TITLE
use window.innerHeight instead of document.documentElement.clientHeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const MyHalfHeightExampleComponent = ({ children }) => {
 
 Under the hood `use100vh` uses `measureHeight` function which is exported as
 well, so feel free to use it, even without React. Currently it returns
-`document.documentElement?.clientHeight || window.innerHeight` or `null`.
+`window.innerHeight` in a browser and `null` in Node.
 
 ## Testing
 

--- a/packages/react-div-100vh/package.json
+++ b/packages/react-div-100vh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-div-100vh",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.1",
   "description": "A workaround for the '100vh' issue in mobile browsers",
   "license": "MIT",
   "main": "dist/cjs/index.js",

--- a/packages/react-div-100vh/src/index.tsx
+++ b/packages/react-div-100vh/src/index.tsx
@@ -46,7 +46,7 @@ export function use100vh(): number | null {
 
 export function measureHeight(): number | null {
   if (!isClient()) return null
-  return document.documentElement?.clientHeight || window.innerHeight
+  return window.innerHeight
 }
 
 // Once we ended up on the client, the first render must look the same as on


### PR DESCRIPTION
After experimenting in BrowserStack with Safari on iOS versions from 10 to 15, I can confirm that `document.documentElement.clientHeight` is only updated after orientation change, so `resize` events caused by shrinking / enlarging of the URL panel don't have effect on `document.documentElement.clientHeight`, while `window.innerHeight` is being updated.

For reference (it was mentioned in #22 - the original reason to switch from `window.innerHeight` to `document.documentElement.clientHeight`, something that I revert here) - trying to extract values from  `document.documentElement.clientHeight` and `window.innerHeight` won't work properly in the `orientationchange` event handler (the values are gibberish as the 4,5 year old bug https://bugs.webkit.org/show_bug.cgi?id=170595 is still not resolved), but iOS fires `resize` event after `orientationchange` where at least  `window.innerHeight` looks correct, so I don't debounce `orientationchange` and rely on the `resize` event that follows.

I noticed that iOS 15 fires way more `resize` events on URL bar size change, so debouncing might still be necessary. But I will leave that for another update.

I also tried in Chrome on Android versions 8-11, the behavior is identical to iOS.